### PR TITLE
Refactor uniswap oracle

### DIFF
--- a/contracts/oracles/ChainlinkUniswapV3Oracle.sol
+++ b/contracts/oracles/ChainlinkUniswapV3Oracle.sol
@@ -22,9 +22,16 @@ contract ChainlinkUniswapV3Oracle is ChainlinkCollateralAdapter, UniswapV3Borrow
     /// @dev The scale must be 1e36 * 10^(decimals of borrowable token - decimals of collateral token).
     uint256 public immutable PRICE_SCALE;
 
-    constructor(address feed, address pool, uint32 borrowablePriceDelay, uint256 scale)
+    constructor(
+        address feed,
+        address pool,
+        uint32 borrowablePriceDelay,
+        uint256 scale,
+        address borrowableToken,
+        address quoteToken
+    )
         ChainlinkCollateralAdapter(feed)
-        UniswapV3BorrowableAdapter(pool, borrowablePriceDelay)
+        UniswapV3BorrowableAdapter(pool, borrowablePriceDelay, borrowableToken, quoteToken)
     {
         PRICE_SCALE = scale;
     }
@@ -41,7 +48,8 @@ contract ChainlinkUniswapV3Oracle is ChainlinkCollateralAdapter, UniswapV3Borrow
         return FullMath.mulDiv(
             CHAINLINK_COLLATERAL_FEED.price() * WAD,
             PRICE_SCALE, // Using FullMath to avoid overflowing because of PRICE_SCALE.
-            UNI_V3_BORROWABLE_POOL.price(UNI_V3_BORROWABLE_DELAY) * CHAINLINK_COLLATERAL_PRICE_SCALE
+            UNI_V3_BORROWABLE_POOL.price(UNI_V3_BORROWABLE_DELAY, BORROWABLE_TOKEN, BORROWABLE_QUOTE_TOKEN)
+                * CHAINLINK_COLLATERAL_PRICE_SCALE
         );
     }
 }

--- a/contracts/oracles/UniswapV3ChainlinkOracle.sol
+++ b/contracts/oracles/UniswapV3ChainlinkOracle.sol
@@ -22,8 +22,15 @@ contract UniswapV3ChainlinkOracle is UniswapV3CollateralAdapter, ChainlinkBorrow
     /// @dev The scale must be 1e36 * 10^(decimals of borrowable token - decimals of collateral token).
     uint256 public immutable PRICE_SCALE;
 
-    constructor(address pool, address feed, uint32 collateralPriceDelay, uint256 scale)
-        UniswapV3CollateralAdapter(pool, collateralPriceDelay)
+    constructor(
+        address pool,
+        address feed,
+        uint32 collateralPriceDelay,
+        uint256 scale,
+        address collateralToken,
+        address quoteToken
+    )
+        UniswapV3CollateralAdapter(pool, collateralPriceDelay, collateralToken, quoteToken)
         ChainlinkBorrowableAdapter(feed)
     {
         PRICE_SCALE = scale;
@@ -39,7 +46,8 @@ contract UniswapV3ChainlinkOracle is UniswapV3CollateralAdapter, ChainlinkBorrow
 
     function price() external view returns (uint256) {
         return FullMath.mulDiv(
-            UNI_V3_COLLATERAL_POOL.price(UNI_V3_COLLATERAL_DELAY) * CHAINLINK_BORROWABLE_PRICE_SCALE,
+            UNI_V3_COLLATERAL_POOL.price(UNI_V3_COLLATERAL_DELAY, COLLATERAL_TOKEN, COLLATERAL_QUOTE_TOKEN)
+                * CHAINLINK_BORROWABLE_PRICE_SCALE,
             PRICE_SCALE, // Using FullMath to avoid overflowing because of PRICE_SCALE.
             CHAINLINK_BORROWABLE_FEED.price() * WAD
         );

--- a/contracts/oracles/UniswapV3Oracle.sol
+++ b/contracts/oracles/UniswapV3Oracle.sol
@@ -12,7 +12,9 @@ import {UniswapV3CollateralAdapter} from "./adapters/UniswapV3CollateralAdapter.
 contract UniswapV3Oracle is UniswapV3CollateralAdapter, IOracle {
     using UniswapV3PoolLib for IUniswapV3Pool;
 
-    constructor(address pool, uint32 delay) UniswapV3CollateralAdapter(pool, delay) {}
+    constructor(address pool, uint32 delay, address collateralToken, address quoteToken)
+        UniswapV3CollateralAdapter(pool, delay, collateralToken, quoteToken)
+    {}
 
     function FEED_COLLATERAL() external view returns (string memory, address) {
         return (OracleFeed.UNISWAP_V3, address(UNI_V3_COLLATERAL_POOL));
@@ -21,6 +23,6 @@ contract UniswapV3Oracle is UniswapV3CollateralAdapter, IOracle {
     function FEED_BORROWABLE() external view returns (string memory, address) {}
 
     function price() external view returns (uint256) {
-        return UNI_V3_COLLATERAL_POOL.price(UNI_V3_COLLATERAL_DELAY);
+        return UNI_V3_COLLATERAL_POOL.price(UNI_V3_COLLATERAL_DELAY, COLLATERAL_TOKEN, COLLATERAL_QUOTE_TOKEN);
     }
 }

--- a/contracts/oracles/UniswapV3PairOracle.sol
+++ b/contracts/oracles/UniswapV3PairOracle.sol
@@ -24,10 +24,13 @@ contract UniswapV3Oracle is UniswapV3CollateralAdapter, UniswapV3BorrowableAdapt
         address borrowablePool,
         uint32 collateralPriceDelay,
         uint32 borrowablePriceDelay,
+        address collateralToken,
+        address borrowableToken,
+        address quoteToken,
         uint256 scale
     )
-        UniswapV3CollateralAdapter(collateralPool, collateralPriceDelay)
-        UniswapV3BorrowableAdapter(borrowablePool, borrowablePriceDelay)
+        UniswapV3CollateralAdapter(collateralPool, collateralPriceDelay, collateralToken, quoteToken)
+        UniswapV3BorrowableAdapter(borrowablePool, borrowablePriceDelay, borrowableToken, quoteToken)
     {
         PRICE_SCALE = scale;
     }
@@ -42,9 +45,9 @@ contract UniswapV3Oracle is UniswapV3CollateralAdapter, UniswapV3BorrowableAdapt
 
     function price() external view returns (uint256) {
         return FullMath.mulDiv(
-            UNI_V3_COLLATERAL_POOL.price(UNI_V3_COLLATERAL_DELAY),
+            UNI_V3_COLLATERAL_POOL.price(UNI_V3_COLLATERAL_DELAY, COLLATERAL_TOKEN, COLLATERAL_QUOTE_TOKEN),
             PRICE_SCALE,
-            UNI_V3_BORROWABLE_POOL.price(UNI_V3_BORROWABLE_DELAY)
+            UNI_V3_BORROWABLE_POOL.price(UNI_V3_BORROWABLE_DELAY, BORROWABLE_TOKEN, BORROWABLE_QUOTE_TOKEN)
         );
     }
 }

--- a/contracts/oracles/adapters/UniswapV3BorrowableAdapter.sol
+++ b/contracts/oracles/adapters/UniswapV3BorrowableAdapter.sol
@@ -6,9 +6,13 @@ import {IUniswapV3Pool} from "@uniswap/v3-core/interfaces/IUniswapV3Pool.sol";
 abstract contract UniswapV3BorrowableAdapter {
     IUniswapV3Pool public immutable UNI_V3_BORROWABLE_POOL;
     uint32 public immutable UNI_V3_BORROWABLE_DELAY;
+    address public immutable BORROWABLE_TOKEN;
+    address public immutable BORROWABLE_QUOTE_TOKEN;
 
-    constructor(address pool, uint32 delay) {
+    constructor(address pool, uint32 delay, address borrowableToken, address quoteToken) {
         UNI_V3_BORROWABLE_POOL = IUniswapV3Pool(pool);
         UNI_V3_BORROWABLE_DELAY = delay;
+        BORROWABLE_TOKEN = borrowableToken;
+        BORROWABLE_QUOTE_TOKEN = quoteToken;
     }
 }

--- a/contracts/oracles/adapters/UniswapV3CollateralAdapter.sol
+++ b/contracts/oracles/adapters/UniswapV3CollateralAdapter.sol
@@ -6,9 +6,13 @@ import {IUniswapV3Pool} from "@uniswap/v3-core/interfaces/IUniswapV3Pool.sol";
 abstract contract UniswapV3CollateralAdapter {
     IUniswapV3Pool public immutable UNI_V3_COLLATERAL_POOL;
     uint32 public immutable UNI_V3_COLLATERAL_DELAY;
+    address public immutable COLLATERAL_TOKEN;
+    address public immutable COLLATERAL_QUOTE_TOKEN;
 
-    constructor(address pool, uint32 delay) {
+    constructor(address pool, uint32 delay, address collateralToken, address quoteToken) {
         UNI_V3_COLLATERAL_POOL = IUniswapV3Pool(pool);
         UNI_V3_COLLATERAL_DELAY = delay;
+        COLLATERAL_TOKEN = collateralToken;
+        COLLATERAL_QUOTE_TOKEN = quoteToken;
     }
 }

--- a/contracts/oracles/libraries/UniswapV3PoolLib.sol
+++ b/contracts/oracles/libraries/UniswapV3PoolLib.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
 import {FullMath} from "@uniswap/v3-core/libraries/FullMath.sol";
 import {TickMath} from "@uniswap/v3-core/libraries/TickMath.sol";
 import {IUniswapV3Pool} from "@uniswap/v3-core/interfaces/IUniswapV3Pool.sol";
@@ -8,11 +10,15 @@ import {IUniswapV3Pool} from "@uniswap/v3-core/interfaces/IUniswapV3Pool.sol";
 /// @title UniswapV3PoolLib
 /// @notice Provides functions to integrate with a V3 pool, as an oracle.
 library UniswapV3PoolLib {
-    /// @notice Calculates time-weighted average price of a pool over a given duration.
+    /// @notice Calculates time-weighted means of tick for a given Uniswap V3 pool.
     /// @param pool Address of the pool that we want to observe.
-    /// @param secondsAgo Number of seconds in the past from which to calculate the time-weighted average.
-    /// @return The time-weighted average price from (block.timestamp - secondsAgo) to block.timestamp.
-    function price(IUniswapV3Pool pool, uint32 secondsAgo) internal view returns (uint256) {
+    /// @param secondsAgo Number of seconds in the past from which to calculate the time-weighted means.
+    /// @return arithmeticMeanTick The arithmetic mean tick from (block.timestamp - secondsAgo) to block.timestamp.
+    function getArithmeticMeanTick(IUniswapV3Pool pool, uint32 secondsAgo)
+        internal
+        view
+        returns (int24 arithmeticMeanTick)
+    {
         uint32[] memory secondsAgos = new uint32[](2);
         secondsAgos[0] = secondsAgo;
         secondsAgos[1] = 0;
@@ -21,21 +27,46 @@ library UniswapV3PoolLib {
 
         int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
 
-        int24 arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
+        arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
         // Always round to negative infinity.
         if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(secondsAgo)) != 0)) arithmeticMeanTick--;
+    }
 
-        uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(arithmeticMeanTick);
+    /// @notice Given a tick and a token amount, calculates the amount of token received in exchange.
+    /// @param tick Tick value used to calculate the quote.
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination.
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination.
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken.
+    function getQuoteAtTick(int24 tick, address baseToken, address quoteToken)
+        internal
+        view
+        returns (uint256 quoteAmount)
+    {
+        uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
+        uint256 baseAmount = 10 ** ERC20(baseToken).decimals(); // Take a baseAmount of 1 token.
 
-        // Calculate price with better precision if it doesn't overflow when multiplied by itself.
+        // Calculate quoteAmount with better precision if it doesn't overflow when multiplied by itself
         if (sqrtRatioX96 <= type(uint128).max) {
             uint256 ratioX192 = uint256(sqrtRatioX96) * sqrtRatioX96;
 
-            return FullMath.mulDiv(ratioX192, 1e18, 1 << 192);
+            quoteAmount = baseToken < quoteToken
+                ? FullMath.mulDiv(ratioX192, baseAmount, 1 << 192)
+                : FullMath.mulDiv(1 << 192, baseAmount, ratioX192);
         } else {
             uint256 ratioX128 = FullMath.mulDiv(sqrtRatioX96, sqrtRatioX96, 1 << 64);
 
-            return FullMath.mulDiv(ratioX128, 1e18, 1 << 128);
+            quoteAmount = baseToken < quoteToken
+                ? FullMath.mulDiv(ratioX128, baseAmount, 1 << 128)
+                : FullMath.mulDiv(1 << 128, baseAmount, ratioX128);
         }
+    }
+
+    function price(IUniswapV3Pool pool, uint32 secondsAgo, address baseToken, address quoteToken)
+        internal
+        view
+        returns (uint256)
+    {
+        int24 arithmeticMeanTick = getArithmeticMeanTick(pool, secondsAgo);
+        return getQuoteAtTick(arithmeticMeanTick, baseToken, quoteToken);
     }
 }


### PR DESCRIPTION
Adding the base token, base amount and quote token because the order between the tokens of a pool has consequences on the price output. There might be a cleaner way to do handler this problem. Open to suggestions.

Based on [Uniswap v3 periphery code](https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/OracleLibrary.sol#L55).