### PR TITLE
refactor(bundler): use evm bundler instead of composition

### DIFF
--- a/contracts/bundlers/EVMBundler.sol
+++ b/contracts/bundlers/EVMBundler.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.21;
 
-import {MorphoBundler} from "./MorphoBundler.sol";
 import {ERC20Bundler} from "./ERC20Bundler.sol";
+import {ERC4626Bundler} from "./ERC4626Bundler.sol";
+import {MorphoBundler} from "./MorphoBundler.sol";
 
 /// @title EVMBundler
 /// @author Morpho Labs
 /// @custom:contact security@morpho.xyz
 /// @notice Common bundler layer guaranteeing it can be deployed to the same address on all EVM-compatible chains.
-contract EVMBundler is ERC20Bundler, MorphoBundler {
+contract EVMBundler is ERC20Bundler, ERC4626Bundler, MorphoBundler {
     constructor(address morpho) MorphoBundler(morpho) {}
 }

--- a/contracts/bundlers/ethereum-mainnet/EthereumBundler.sol
+++ b/contracts/bundlers/ethereum-mainnet/EthereumBundler.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.21;
 
-import {ERC20Bundler} from "../ERC20Bundler.sol";
-import {ERC4626Bundler} from "../ERC4626Bundler.sol";
+import {EVMBundler} from "../EVMBundler.sol";
 import {MorphoBundler} from "../MorphoBundler.sol";
 import {WNativeBundler} from "../WNativeBundler.sol";
 import {StEthBundler} from "./StEthBundler.sol";
@@ -10,13 +9,13 @@ import {StEthBundler} from "./StEthBundler.sol";
 /// @title EthereumBundler
 /// @author Morpho Labs
 /// @custom:contact security@morpho.xyz
-contract EthereumBundler is ERC20Bundler, ERC4626Bundler, WNativeBundler, StEthBundler, MorphoBundler {
+contract EthereumBundler is EVMBundler, WNativeBundler, StEthBundler {
     /* CONSTANTS */
 
-    /// @dev The address of the WETH contract on Ethreum mainnet.
+    /// @dev The address of the WETH contract on Ethereum mainnet.
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     /* CONSTRUCTOR */
 
-    constructor(address morpho) WNativeBundler(WETH) MorphoBundler(morpho) {}
+    constructor(address morpho) EVMBundler(morpho) WNativeBundler(WETH) {}
 }

--- a/test/forge/ethereum-mainnet/EthereumBundlerEthereumTest.sol
+++ b/test/forge/ethereum-mainnet/EthereumBundlerEthereumTest.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {IAllowanceTransfer} from "@permit2/interfaces/IAllowanceTransfer.sol";
 
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {ERC20Bundler} from "contracts/bundlers/ERC20Bundler.sol";
 
 import "contracts/bundlers/ethereum-mainnet/EthereumBundler.sol";
 


### PR DESCRIPTION
It avoids to forget about what the base evm bundler is made of (ERC20, ERC4626 & Morpho atm)