### PR TITLE
refactor(modifier): abstract checkInitiated to a modifier

### DIFF
--- a/src/BaseBundler.sol
+++ b/src/BaseBundler.sol
@@ -37,6 +37,13 @@ abstract contract BaseBundler is IMulticall {
         delete _initiator;
     }
 
+    /// @dev Checks that the contract is in an initiated execution context.
+    modifier onlyInitiated() {
+        require(_initiator != address(0), ErrorsLib.UNINITIATED);
+
+        _;
+    }
+
     /* PUBLIC */
 
     /// @notice Executes a series of delegate calls to the contract itself.
@@ -98,11 +105,6 @@ abstract contract BaseBundler is IMulticall {
             // No need to check that `address(this)` has code in case of success.
             if (!success) _revert(returnData);
         }
-    }
-
-    /// @dev Checks that the contract is in an initiated execution context.
-    function _checkInitiated() internal view {
-        require(_initiator != address(0), ErrorsLib.UNINITIATED);
     }
 
     /// @dev Bubbles up the revert reason / custom error encoded in `returnData`.

--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -33,22 +33,22 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
 
     /* CALLBACKS */
 
-    function onMorphoSupply(uint256, bytes calldata data) external {
+    function onMorphoSupply(uint256, bytes calldata data) external onlyInitiated {
         // Don't need to approve Morpho to pull tokens because it should already be approved max.
         _callback(data);
     }
 
-    function onMorphoSupplyCollateral(uint256, bytes calldata data) external {
+    function onMorphoSupplyCollateral(uint256, bytes calldata data) external onlyInitiated {
         // Don't need to approve Morpho to pull tokens because it should already be approved max.
         _callback(data);
     }
 
-    function onMorphoRepay(uint256, bytes calldata data) external {
+    function onMorphoRepay(uint256, bytes calldata data) external onlyInitiated {
         // Don't need to approve Morpho to pull tokens because it should already be approved max.
         _callback(data);
     }
 
-    function onMorphoFlashLoan(uint256, bytes calldata data) external {
+    function onMorphoFlashLoan(uint256, bytes calldata data) external onlyInitiated {
         // Don't need to approve Morpho to pull tokens because it should already be approved max.
         _callback(data);
     }
@@ -185,8 +185,6 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
 
     /// @dev Triggers `_multicall` logic during a callback.
     function _callback(bytes calldata data) internal {
-        _checkInitiated();
-
         _multicall(abi.decode(data, (bytes[])));
     }
 


### PR DESCRIPTION
- Fixes #252 

The rationale is that guards are widely written and expected as modifiers ; so we should keep this privileged view of modifiers for accustomed reviewers