### PR TITLE
Fix : add requirements, consequences and side effects natspec - issue 26

### DIFF
--- a/src/ERC4626Bundler.sol
+++ b/src/ERC4626Bundler.sol
@@ -19,6 +19,7 @@ abstract contract ERC4626Bundler is BaseBundler {
     /* ACTIONS */
 
     /// @notice Mints the given amount of `shares` on the given ERC4626 `vault`, on behalf of `owner`.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Assumes the given `vault` implements EIP-4626.
     /// @param vault The address of the vault.
     /// @param shares The amount of shares to mint. Pass `type(uint256).max` to mint max.
@@ -41,6 +42,7 @@ abstract contract ERC4626Bundler is BaseBundler {
     }
 
     /// @notice Deposits the given amount of `assets` on the given ERC4626 `vault`, on behalf of `owner`.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Assumes the given `vault` implements EIP-4626.
     /// @param vault The address of the vault.
     /// @param assets The amount of assets to deposit. Pass `type(uint256).max` to deposit max.

--- a/src/ERC4626Bundler.sol
+++ b/src/ERC4626Bundler.sol
@@ -19,7 +19,7 @@ abstract contract ERC4626Bundler is BaseBundler {
     /* ACTIONS */
 
     /// @notice Mints the given amount of `shares` on the given ERC4626 `vault`, on behalf of `owner`.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Assumes the given `vault` implements EIP-4626.
     /// @param vault The address of the vault.
     /// @param shares The amount of shares to mint. Pass `type(uint256).max` to mint max.
@@ -42,7 +42,7 @@ abstract contract ERC4626Bundler is BaseBundler {
     }
 
     /// @notice Deposits the given amount of `assets` on the given ERC4626 `vault`, on behalf of `owner`.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Assumes the given `vault` implements EIP-4626.
     /// @param vault The address of the vault.
     /// @param assets The amount of assets to deposit. Pass `type(uint256).max` to deposit max.

--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -72,6 +72,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
 
     /// @notice Supplies `amount` of the loan asset on behalf of `onBehalf`.
     /// @notice The supplied amount cannot be used as collateral but is eligible to earn interest.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to supply the bundler's loan asset balance.
     /// @param marketParams The Morpho market to supply assets to.
     /// @param amount The amount of assets to supply.
@@ -98,6 +99,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Supplies `amount` of the collateral asset on behalf of `onBehalf`.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to supply the bundler's collateral asset balance.
     /// @param marketParams The Morpho market to supply collateral to.
     /// @param amount The amount of collateral to supply.
@@ -136,6 +138,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Repays `amount` of the loan asset on behalf of `onBehalf`.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to repay the bundler's loan asset balance.
     /// @param marketParams The Morpho market to repay assets to.
     /// @param amount The amount of assets to repay.
@@ -189,6 +192,10 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Triggers a liquidation on Morpho.
+    /// @notice Seized collateral must be transferred from the Bundler to a receiver (via a proper action inside the
+    /// multicall).
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @param marketParams The Morpho market of the position.
     /// @param borrower The owner of the position.
     /// @param seizedCollateral The amount of collateral to seize.

--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -123,7 +123,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
         MORPHO.supplyCollateral(marketParams, amount, onBehalf, data);
     }
 
-    /// @notice Borrows `amount` of the loan asset on behalf of the sender.
+    /// @notice Borrows `amount` of the loan asset on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously authorized the bundler to act on their behalf on Morpho.
     /// @param marketParams The Morpho market to borrow assets from.
@@ -163,7 +163,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
         MORPHO.repay(marketParams, amount, shares, onBehalf, data);
     }
 
-    /// @notice Withdraws `amount` of the loan asset on behalf of `onBehalf`.
+    /// @notice Withdraws `amount` of the loan asset on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously authorized the bundler to act on their behalf on Morpho.
     /// @param marketParams The Morpho market to withdraw assets from.
@@ -177,7 +177,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
         MORPHO.withdraw(marketParams, amount, shares, initiator(), receiver);
     }
 
-    /// @notice Withdraws `amount` of the collateral asset on behalf of sender.
+    /// @notice Withdraws `amount` of the collateral asset on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously authorized the bundler to act on their behalf on Morpho.
     /// @param marketParams The Morpho market to withdraw collateral from.

--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -73,9 +73,9 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     /// @notice Supplies `amount` of the loan asset on behalf of `onBehalf`.
     /// @notice The supplied amount cannot be used as collateral but is eligible to earn interest.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to supply the bundler's loan asset balance.
     /// @param marketParams The Morpho market to supply assets to.
-    /// @param amount The amount of assets to supply.
+    /// @param amount The amount of assets to supply. Pass `type(uint256).max` to supply the bundler's loan asset
+    /// balance.
     /// @param shares The amount of shares to mint.
     /// @param onBehalf The address that will own the increased supply position.
     /// @param data Arbitrary data to pass to the `onMorphoSupply` callback. Pass empty data if not needed.
@@ -100,9 +100,9 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
 
     /// @notice Supplies `amount` of the collateral asset on behalf of `onBehalf`.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to supply the bundler's collateral asset balance.
     /// @param marketParams The Morpho market to supply collateral to.
-    /// @param amount The amount of collateral to supply.
+    /// @param amount The amount of collateral to supply. Pass `type(uint256).max` to supply the bundler's loan asset
+    /// balance.
     /// @param onBehalf The address that will own the increased collateral position.
     /// @param data Arbitrary data to pass to the `onMorphoSupplyCollateral` callback. Pass empty data if not needed.
     function morphoSupplyCollateral(
@@ -139,9 +139,8 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
 
     /// @notice Repays `amount` of the loan asset on behalf of `onBehalf`.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to repay the bundler's loan asset balance.
     /// @param marketParams The Morpho market to repay assets to.
-    /// @param amount The amount of assets to repay.
+    /// @param amount The amount of assets to repay. Pass `type(uint256).max` to repay the bundler's loan asset balance.
     /// @param shares The amount of shares to burn.
     /// @param onBehalf The address of the owner of the debt position.
     /// @param data Arbitrary data to pass to the `onMorphoRepay` callback. Pass empty data if not needed.
@@ -192,8 +191,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Triggers a liquidation on Morpho.
-    /// @notice Seized collateral must be transferred from the bundler to a receiver afterwards (via
-    /// `TransferBundler.erc20Transfer`).
+    /// @notice Seized collateral is received by the bundler and should be used afterwards.
     /// @param marketParams The Morpho market of the position.
     /// @param borrower The owner of the position.
     /// @param seizedCollateral The amount of collateral to seize.

--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -72,7 +72,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
 
     /// @notice Supplies `amount` of the loan asset on behalf of `onBehalf`.
     /// @notice The supplied amount cannot be used as collateral but is eligible to earn interest.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to supply the bundler's loan asset balance.
     /// @param marketParams The Morpho market to supply assets to.
     /// @param amount The amount of assets to supply.
@@ -99,7 +99,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Supplies `amount` of the collateral asset on behalf of `onBehalf`.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to supply the bundler's collateral asset balance.
     /// @param marketParams The Morpho market to supply collateral to.
     /// @param amount The amount of collateral to supply.
@@ -138,7 +138,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Repays `amount` of the loan asset on behalf of `onBehalf`.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to repay the bundler's loan asset balance.
     /// @param marketParams The Morpho market to repay assets to.
     /// @param amount The amount of assets to repay.
@@ -192,10 +192,8 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
     }
 
     /// @notice Triggers a liquidation on Morpho.
-    /// @notice Seized collateral must be transferred from the Bundler to a receiver (via a proper action inside the
-    /// multicall).
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
+    /// @notice Seized collateral must be transferred from the bundler to a receiver afterwards (via
+    /// `TransferBundler.erc20Transfer`).
     /// @param marketParams The Morpho market of the position.
     /// @param borrower The owner of the position.
     /// @param seizedCollateral The amount of collateral to seize.

--- a/src/Permit2Bundler.sol
+++ b/src/Permit2Bundler.sol
@@ -19,6 +19,7 @@ abstract contract Permit2Bundler is BaseBundler {
 
     /// @notice Permits and performs a transfer from the initiator to the recipient via Permit2.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have given sufficient allowance to the Permit2 contract to manage his tokens.
     /// @dev Pass `permit.permitted.amount = type(uint256).max` to transfer all.
     /// @param permit The `PermitTransferFrom` struct.
     /// @param signature The signature.

--- a/src/StEthBundler.sol
+++ b/src/StEthBundler.sol
@@ -41,10 +41,8 @@ abstract contract StEthBundler is BaseBundler {
 
     /// @notice Stakes the given `amount` of ETH via Lido, using the `referral` id.
     /// @notice User must have transferred the needed amount of native tokens before the execution.
-    /// @notice Staked stEth must be transferred from the Bundler to a receiver (via a proper action inside the
-    /// multicall).
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
+    /// @notice Staked stEth must be transferred from the Bundler to a receiver afterwards (via
+    /// `TransferBundler.erc20Transfer`).
     /// @dev Pass `amount = type(uint256).max` to stake all.
     /// @param amount The amount of ETH to stake.
     /// @param referral The address of the referral regarding the Lido Rewards-Share Program.
@@ -57,10 +55,8 @@ abstract contract StEthBundler is BaseBundler {
 
     /// @notice Wraps the given `amount` of stETH to wstETH.
     /// @notice User must have transferred the needed amount of stETH before the execution.
-    /// @notice Wrapped wstEth must be transferred from the Bundler to a receiver (via a proper action inside the
-    /// multicall).
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
+    /// @notice Wrapped wstEth must be transferred from the Bundler to a receiver afterwards (via
+    /// `TransferBundler.erc20Transfer`).
     /// @dev Pass `amount = type(uint256).max` to wrap all.
     /// @param amount The amount of stEth to wrap.
     function wrapStEth(uint256 amount) external payable {
@@ -73,10 +69,8 @@ abstract contract StEthBundler is BaseBundler {
 
     /// @notice Unwraps the given `amount` of wstETH to stETH.
     /// @notice User must have transferred the needed amount of wstETH before the execution.
-    /// @notice Unwrapped stEth must be transferred from the Bundler to a receiver (via a proper action inside the
-    /// multicall).
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
+    /// @notice Unwrapped stEth must be transferred from the Bundler to a receiver afterwards (via
+    /// `TransferBundler.erc20Transfer`).
     /// @dev Pass `amount = type(uint256).max` to unwrap all.
     /// @param amount The amount of wstEth to unwrap.
     function unwrapStEth(uint256 amount) external payable {

--- a/src/StEthBundler.sol
+++ b/src/StEthBundler.sol
@@ -40,6 +40,11 @@ abstract contract StEthBundler is BaseBundler {
     /* ACTIONS */
 
     /// @notice Stakes the given `amount` of ETH via Lido, using the `referral` id.
+    /// @notice User must have transferred the needed amount of native tokens before the execution.
+    /// @notice Staked stEth must be transferred from the Bundler to a receiver (via a proper action inside the
+    /// multicall).
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to stake all.
     /// @param amount The amount of ETH to stake.
     /// @param referral The address of the referral regarding the Lido Rewards-Share Program.
@@ -51,6 +56,11 @@ abstract contract StEthBundler is BaseBundler {
     }
 
     /// @notice Wraps the given `amount` of stETH to wstETH.
+    /// @notice User must have transferred the needed amount of stETH before the execution.
+    /// @notice Wrapped wstEth must be transferred from the Bundler to a receiver (via a proper action inside the
+    /// multicall).
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to wrap all.
     /// @param amount The amount of stEth to wrap.
     function wrapStEth(uint256 amount) external payable {
@@ -62,6 +72,11 @@ abstract contract StEthBundler is BaseBundler {
     }
 
     /// @notice Unwraps the given `amount` of wstETH to stETH.
+    /// @notice User must have transferred the needed amount of wstETH before the execution.
+    /// @notice Unwrapped stEth must be transferred from the Bundler to a receiver (via a proper action inside the
+    /// multicall).
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to unwrap all.
     /// @param amount The amount of wstEth to unwrap.
     function unwrapStEth(uint256 amount) external payable {

--- a/src/StEthBundler.sol
+++ b/src/StEthBundler.sol
@@ -40,11 +40,9 @@ abstract contract StEthBundler is BaseBundler {
     /* ACTIONS */
 
     /// @notice Stakes the given `amount` of ETH via Lido, using the `referral` id.
-    /// @notice User must have transferred the needed amount of native tokens before the execution.
-    /// @notice Staked stEth must be transferred from the Bundler to a receiver afterwards (via
-    /// `TransferBundler.erc20Transfer`).
-    /// @dev Pass `amount = type(uint256).max` to stake all.
-    /// @param amount The amount of ETH to stake.
+    /// @notice stETH tokens are received by the bundler and should be used afterwards.
+    /// @dev Initiator must have previously transferred their ETH to the bundler.
+    /// @param amount The amount of ETH to stake. Pass `type(uint256).max` to stake all.
     /// @param referral The address of the referral regarding the Lido Rewards-Share Program.
     function stakeEth(uint256 amount, address referral) external payable {
         amount = Math.min(amount, address(this).balance);
@@ -54,11 +52,9 @@ abstract contract StEthBundler is BaseBundler {
     }
 
     /// @notice Wraps the given `amount` of stETH to wstETH.
-    /// @notice User must have transferred the needed amount of stETH before the execution.
-    /// @notice Wrapped wstEth must be transferred from the Bundler to a receiver afterwards (via
-    /// `TransferBundler.erc20Transfer`).
-    /// @dev Pass `amount = type(uint256).max` to wrap all.
-    /// @param amount The amount of stEth to wrap.
+    /// @notice wstETH tokens are received by the bundler and should be used afterwards.
+    /// @dev Initiator must have previously transferred their stETH tokens to the bundler.
+    /// @param amount The amount of stEth to wrap. Pass `type(uint256).max` to wrap all.
     function wrapStEth(uint256 amount) external payable {
         amount = Math.min(amount, ERC20(ST_ETH).balanceOf(address(this)));
 
@@ -68,11 +64,9 @@ abstract contract StEthBundler is BaseBundler {
     }
 
     /// @notice Unwraps the given `amount` of wstETH to stETH.
-    /// @notice User must have transferred the needed amount of wstETH before the execution.
-    /// @notice Unwrapped stEth must be transferred from the Bundler to a receiver afterwards (via
-    /// `TransferBundler.erc20Transfer`).
-    /// @dev Pass `amount = type(uint256).max` to unwrap all.
-    /// @param amount The amount of wstEth to unwrap.
+    /// @notice stETH tokens are received by the bundler and should be used afterwards.
+    /// @dev Initiator must have previously transferred their wstETH tokens to the bundler.
+    /// @param amount The amount of wstEth to unwrap. Pass `type(uint256).max` to unwrap all.
     function unwrapStEth(uint256 amount) external payable {
         amount = Math.min(amount, ERC20(WST_ETH).balanceOf(address(this)));
 

--- a/src/TransferBundler.sol
+++ b/src/TransferBundler.sol
@@ -20,8 +20,8 @@ abstract contract TransferBundler is BaseBundler {
     /// @notice Transfers the minimum between the given `amount` and the bundler's balance of native asset from the
     /// bundler to `recipient`.
     /// @param recipient The address that will receive the native tokens.
-    /// @param amount The amount of native tokens to transfer. Pass `type(uint256).max` to transfer the initiator's
-    /// balance.
+    /// @param amount The amount of native tokens to transfer from the initiator. Pass `type(uint256).max` to transfer
+    /// the initiator's balance.
     function nativeTransfer(address recipient, uint256 amount) external payable {
         require(recipient != address(0), ErrorsLib.ZERO_ADDRESS);
         require(recipient != address(this), ErrorsLib.BUNDLER_ADDRESS);
@@ -54,8 +54,7 @@ abstract contract TransferBundler is BaseBundler {
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @param asset The address of the ERC20 token to transfer.
     /// @param amount The amount of `asset` to transfer from the initiator. Pass `type(uint256).max` to transfer the
-    /// initiator's
-    /// balance.
+    /// initiator's balance.
     function erc20TransferFrom(address asset, uint256 amount) external payable {
         address initiator = initiator();
         amount = Math.min(amount, ERC20(asset).balanceOf(initiator));

--- a/src/TransferBundler.sol
+++ b/src/TransferBundler.sol
@@ -19,9 +19,9 @@ abstract contract TransferBundler is BaseBundler {
 
     /// @notice Transfers the minimum between the given `amount` and the bundler's balance of native asset from the
     /// bundler to `recipient`.
-    /// @dev Pass `amount = type(uint256).max` to transfer all.
     /// @param recipient The address that will receive the native tokens.
-    /// @param amount The amount of native tokens to transfer.
+    /// @param amount The amount of native tokens to transfer. Pass `type(uint256).max` to transfer the initiator's
+    /// balance.
     function nativeTransfer(address recipient, uint256 amount) external payable {
         require(recipient != address(0), ErrorsLib.ZERO_ADDRESS);
         require(recipient != address(this), ErrorsLib.BUNDLER_ADDRESS);
@@ -35,10 +35,9 @@ abstract contract TransferBundler is BaseBundler {
 
     /// @notice Transfers the minimum between the given `amount` and the bundler's balance of `asset` from the bundler
     /// to `recipient`.
-    /// @dev Pass `amount = type(uint256).max` to transfer all.
     /// @param asset The address of the ERC20 token to transfer.
     /// @param recipient The address that will receive the tokens.
-    /// @param amount The amount of `asset` to transfer.
+    /// @param amount The amount of `asset` to transfer. Pass `type(uint256).max` to transfer the bundler's balance.
     function erc20Transfer(address asset, address recipient, uint256 amount) external payable {
         require(recipient != address(0), ErrorsLib.ZERO_ADDRESS);
         require(recipient != address(this), ErrorsLib.BUNDLER_ADDRESS);
@@ -53,9 +52,10 @@ abstract contract TransferBundler is BaseBundler {
     /// @notice Transfers the given `amount` of `asset` from sender to this contract via ERC20 transferFrom.
     /// @notice User must have given sufficient allowance to the Bundler to manage his tokens.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @dev Pass `amount = type(uint256).max` to transfer all.
     /// @param asset The address of the ERC20 token to transfer.
-    /// @param amount The amount of `asset` to transfer from the initiator.
+    /// @param amount The amount of `asset` to transfer from the initiator. Pass `type(uint256).max` to transfer the
+    /// initiator's
+    /// balance.
     function erc20TransferFrom(address asset, uint256 amount) external payable {
         address initiator = initiator();
         amount = Math.min(amount, ERC20(asset).balanceOf(initiator));

--- a/src/TransferBundler.sol
+++ b/src/TransferBundler.sol
@@ -51,7 +51,10 @@ abstract contract TransferBundler is BaseBundler {
     }
 
     /// @notice Transfers the given `amount` of `asset` from sender to this contract via ERC20 transferFrom.
+    /// @notice User must have given sufficient allowance to the Bundler to manage his tokens.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to transfer all.
     /// @param asset The address of the ERC20 token to transfer.
     /// @param amount The amount of `asset` to transfer from the initiator.

--- a/src/TransferBundler.sol
+++ b/src/TransferBundler.sol
@@ -53,8 +53,6 @@ abstract contract TransferBundler is BaseBundler {
     /// @notice Transfers the given `amount` of `asset` from sender to this contract via ERC20 transferFrom.
     /// @notice User must have given sufficient allowance to the Bundler to manage his tokens.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to transfer all.
     /// @param asset The address of the ERC20 token to transfer.
     /// @param amount The amount of `asset` to transfer from the initiator.

--- a/src/WNativeBundler.sol
+++ b/src/WNativeBundler.sol
@@ -41,10 +41,8 @@ abstract contract WNativeBundler is BaseBundler {
     /// @notice Wraps the given `amount` of the native token to wNative.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @notice User must have transferred the needed amount of native tokens before the execution.
-    /// @notice Wrapped wNatve must be transferred from the Bundler to a receiver (via a proper action inside the
-    /// multicall).
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
+    /// @notice Wrapped wNatve must be transferred from the Bundler to a receiver afterwards (via
+    /// `TransferBundler.erc20Transfer`).
     /// @dev Pass `amount = type(uint256).max` to wrap all.
     /// @param amount The amount of native token to wrap.
     function wrapNative(uint256 amount) external payable {
@@ -60,8 +58,6 @@ abstract contract WNativeBundler is BaseBundler {
     /// @notice User must have transferred the needed amount of wNative tokens before the execution.
     /// @notice Unwrapped native tokens must be transferred from the Bundler to a receiver (via a proper action inside
     /// the multicall).
-    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
-    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to unwrap all.
     /// @param amount The amount of wrapped native token to unwrap.
     function unwrapNative(uint256 amount) external payable {

--- a/src/WNativeBundler.sol
+++ b/src/WNativeBundler.sol
@@ -40,11 +40,9 @@ abstract contract WNativeBundler is BaseBundler {
 
     /// @notice Wraps the given `amount` of the native token to wNative.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of native tokens before the execution.
-    /// @notice Wrapped wNatve must be transferred from the Bundler to a receiver afterwards (via
-    /// `TransferBundler.erc20Transfer`).
-    /// @dev Pass `amount = type(uint256).max` to wrap all.
-    /// @param amount The amount of native token to wrap.
+    /// @notice Wrapped native tokens are received by the bundler and should be used afterwards.
+    /// @dev Initiator must have previously transferred their native tokens to the bundler.
+    /// @param amount The amount of native token to wrap. Pass `type(uint256).max` to wrap all.
     function wrapNative(uint256 amount) external payable {
         amount = Math.min(amount, address(this).balance);
 
@@ -55,11 +53,9 @@ abstract contract WNativeBundler is BaseBundler {
 
     /// @notice Unwraps the given `amount` of wNative to the native token.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of wNative tokens before the execution.
-    /// @notice Unwrapped native tokens must be transferred from the Bundler to a receiver (via a proper action inside
-    /// the multicall).
-    /// @dev Pass `amount = type(uint256).max` to unwrap all.
-    /// @param amount The amount of wrapped native token to unwrap.
+    /// @notice Unwrapped native tokens are received by the bundler and should be used afterwards.
+    /// @dev Initiator must have previously transferred their wrapped native tokens to the bundler.
+    /// @param amount The amount of wrapped native token to unwrap. Pass `type(uint256).max` to unwrap all.
     function unwrapNative(uint256 amount) external payable {
         amount = Math.min(amount, ERC20(WRAPPED_NATIVE).balanceOf(address(this)));
 

--- a/src/WNativeBundler.sol
+++ b/src/WNativeBundler.sol
@@ -40,6 +40,11 @@ abstract contract WNativeBundler is BaseBundler {
 
     /// @notice Wraps the given `amount` of the native token to wNative.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of native tokens before the execution.
+    /// @notice Wrapped wNatve must be transferred from the Bundler to a receiver (via a proper action inside the
+    /// multicall).
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to wrap all.
     /// @param amount The amount of native token to wrap.
     function wrapNative(uint256 amount) external payable {
@@ -52,6 +57,11 @@ abstract contract WNativeBundler is BaseBundler {
 
     /// @notice Unwraps the given `amount` of wNative to the native token.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of wNative tokens before the execution.
+    /// @notice Unwrapped native tokens must be transferred from the Bundler to a receiver (via a proper action inside
+    /// the multicall).
+    /// @notice Warning: Funds that are not "skimed" at the end of the multicall can be "stolen"/used by the next
+    /// multicall's user.
     /// @dev Pass `amount = type(uint256).max` to unwrap all.
     /// @param amount The amount of wrapped native token to unwrap.
     function unwrapNative(uint256 amount) external payable {

--- a/src/migration/AaveV2MigrationBundler.sol
+++ b/src/migration/AaveV2MigrationBundler.sol
@@ -32,6 +32,7 @@ contract AaveV2MigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `asset` on AaveV2, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param asset The address of the token to repay.
     /// @param amount The amount of `asset` to repay.

--- a/src/migration/AaveV2MigrationBundler.sol
+++ b/src/migration/AaveV2MigrationBundler.sol
@@ -33,9 +33,8 @@ contract AaveV2MigrationBundler is MigrationBundler {
     /// @notice Repays `amount` of `asset` on AaveV2, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param asset The address of the token to repay.
-    /// @param amount The amount of `asset` to repay.
+    /// @param amount The amount of `asset` to repay. Pass `type(uint256).max` to repay the bundler's `asset` balance.
     /// @param interestRateMode The interest rate mode of the position.
     function aaveV2Repay(address asset, uint256 amount, uint256 interestRateMode) external payable {
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
@@ -48,10 +47,10 @@ contract AaveV2MigrationBundler is MigrationBundler {
     }
 
     /// @notice Withdraws `amount` of `asset` on AaveV2, on behalf of the initiator.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously transferred their aTokens to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to withdraw all.
     /// @param asset The address of the token to withdraw.
-    /// @param amount The amount of `asset` to withdraw.
+    /// @param amount The amount of `asset` to withdraw. Pass `type(uint256).max` to withdraw all.
     function aaveV2Withdraw(address asset, uint256 amount) external payable {
         AAVE_V2_POOL.withdraw(asset, amount, address(this));
     }

--- a/src/migration/AaveV2MigrationBundler.sol
+++ b/src/migration/AaveV2MigrationBundler.sol
@@ -32,7 +32,7 @@ contract AaveV2MigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `asset` on AaveV2, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param asset The address of the token to repay.
     /// @param amount The amount of `asset` to repay.

--- a/src/migration/AaveV3MigrationBundler.sol
+++ b/src/migration/AaveV3MigrationBundler.sol
@@ -31,6 +31,7 @@ contract AaveV3MigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `asset` on AaveV3, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param asset The address of the token to repay.
     /// @param amount The amount of `asset` to repay.

--- a/src/migration/AaveV3MigrationBundler.sol
+++ b/src/migration/AaveV3MigrationBundler.sol
@@ -32,9 +32,8 @@ contract AaveV3MigrationBundler is MigrationBundler {
     /// @notice Repays `amount` of `asset` on AaveV3, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param asset The address of the token to repay.
-    /// @param amount The amount of `asset` to repay.
+    /// @param amount The amount of `asset` to repay. Pass `type(uint256).max` to repay the bundler's `asset` balance.
     /// @param interestRateMode The interest rate mode of the position.
     function aaveV3Repay(address asset, uint256 amount, uint256 interestRateMode) external payable {
         amount = Math.min(amount, ERC20(asset).balanceOf(address(this)));
@@ -47,10 +46,10 @@ contract AaveV3MigrationBundler is MigrationBundler {
     }
 
     /// @notice Withdraws `amount` of `asset` on AaveV3, on behalf of the initiator.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously transferred their aTokens to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to withdraw all.
     /// @param asset The address of the token to withdraw.
-    /// @param amount The amount of `asset` to withdraw.
+    /// @param amount The amount of `asset` to withdraw. Pass `type(uint256).max` to withdraw all.
     function aaveV3Withdraw(address asset, uint256 amount) external payable {
         AAVE_V3_POOL.withdraw(asset, amount, address(this));
     }

--- a/src/migration/AaveV3MigrationBundler.sol
+++ b/src/migration/AaveV3MigrationBundler.sol
@@ -31,7 +31,7 @@ contract AaveV3MigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `asset` on AaveV3, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param asset The address of the token to repay.
     /// @param amount The amount of `asset` to repay.

--- a/src/migration/AaveV3OptimizerMigrationBundler.sol
+++ b/src/migration/AaveV3OptimizerMigrationBundler.sol
@@ -32,9 +32,9 @@ contract AaveV3OptimizerMigrationBundler is MigrationBundler {
     /// @notice Repays `amount` of `underlying` on the AaveV3 Optimizer, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param underlying The address of the underlying asset to repay.
-    /// @param amount The amount of `underlying` to repay.
+    /// @param amount The amount of `underlying` to repay. Pass `type(uint256).max` to repay the bundler's `underlying`
+    /// balance.
     function aaveV3OptimizerRepay(address underlying, uint256 amount) external payable {
         amount = Math.min(amount, ERC20(underlying).balanceOf(address(this)));
 
@@ -47,10 +47,10 @@ contract AaveV3OptimizerMigrationBundler is MigrationBundler {
 
     /// @notice Withdraws `amount` of `underlying` on the AaveV3 Optimizer, on behalf of the initiator`.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously approved the bundler to manage their AaveV3 Optimizer position.
-    /// @dev Pass `amount = type(uint256).max` to withdraw all.
     /// @param underlying The address of the underlying asset to withdraw.
-    /// @param amount The amount of `underlying` to withdraw.
+    /// @param amount The amount of `underlying` to withdraw. Pass `type(uint256).max` to withdraw all.
     /// @param maxIterations The maximum number of iterations allowed during the matching process. If it is less than
     /// `_defaultIterations.withdraw`, the latter will be used. Pass 0 to fallback to the `_defaultIterations.withdraw`.
     function aaveV3OptimizerWithdraw(address underlying, uint256 amount, uint256 maxIterations) external payable {
@@ -60,10 +60,10 @@ contract AaveV3OptimizerMigrationBundler is MigrationBundler {
     /// @notice Withdraws `amount` of `underlying` used as collateral on the AaveV3 Optimizer, on behalf of the
     /// initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously approved the bundler to manage their AaveV3 Optimizer position.
-    /// @dev Pass `amount = type(uint256).max` to withdraw all.
     /// @param underlying The address of the underlying asset to withdraw.
-    /// @param amount The amount of `underlying` to withdraw.
+    /// @param amount The amount of `underlying` to withdraw. Pass `type(uint256).max` to withdraw all.
     function aaveV3OptimizerWithdrawCollateral(address underlying, uint256 amount) external payable {
         AAVE_V3_OPTIMIZER.withdrawCollateral(underlying, amount, initiator(), address(this));
     }

--- a/src/migration/AaveV3OptimizerMigrationBundler.sol
+++ b/src/migration/AaveV3OptimizerMigrationBundler.sol
@@ -31,7 +31,7 @@ contract AaveV3OptimizerMigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `underlying` on the AaveV3 Optimizer, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param underlying The address of the underlying asset to repay.
     /// @param amount The amount of `underlying` to repay.

--- a/src/migration/AaveV3OptimizerMigrationBundler.sol
+++ b/src/migration/AaveV3OptimizerMigrationBundler.sol
@@ -31,6 +31,7 @@ contract AaveV3OptimizerMigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `underlying` on the AaveV3 Optimizer, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param underlying The address of the underlying asset to repay.
     /// @param amount The amount of `underlying` to repay.

--- a/src/migration/CompoundV2MigrationBundler.sol
+++ b/src/migration/CompoundV2MigrationBundler.sol
@@ -41,7 +41,7 @@ contract CompoundV2MigrationBundler is WNativeBundler, MigrationBundler {
 
     /// @notice Repays `amount` of `cToken`'s underlying asset, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param cToken The address of the cToken contract
     /// @param amount The amount of `cToken` to repay.

--- a/src/migration/CompoundV2MigrationBundler.sol
+++ b/src/migration/CompoundV2MigrationBundler.sol
@@ -41,6 +41,7 @@ contract CompoundV2MigrationBundler is WNativeBundler, MigrationBundler {
 
     /// @notice Repays `amount` of `cToken`'s underlying asset, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param cToken The address of the cToken contract
     /// @param amount The amount of `cToken` to repay.

--- a/src/migration/CompoundV2MigrationBundler.sol
+++ b/src/migration/CompoundV2MigrationBundler.sol
@@ -42,9 +42,8 @@ contract CompoundV2MigrationBundler is WNativeBundler, MigrationBundler {
     /// @notice Repays `amount` of `cToken`'s underlying asset, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
     /// @dev Initiator must have previously transferred their assets to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param cToken The address of the cToken contract
-    /// @param amount The amount of `cToken` to repay.
+    /// @param amount The amount of `cToken` to repay. Pass `type(uint256).max` to repay all (except for cETH).
     function compoundV2Repay(address cToken, uint256 amount) external payable {
         if (cToken == C_ETH) {
             amount = Math.min(amount, address(this).balance);
@@ -68,10 +67,11 @@ contract CompoundV2MigrationBundler is WNativeBundler, MigrationBundler {
     }
 
     /// @notice Redeems `amount` of `cToken` from CompoundV2.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously transferred their cTokens to the bundler.
-    /// @dev Pass `amount = type(uint256).max` to redeem all.
     /// @param cToken The address of the cToken contract
-    /// @param amount The amount of `cToken` to redeem.
+    /// @param amount The amount of `cToken` to redeem. Pass `type(uint256).max` to redeem the bundler's `cToken`
+    /// balance.
     function compoundV2Redeem(address cToken, uint256 amount) external payable {
         amount = Math.min(amount, ERC20(cToken).balanceOf(address(this)));
 

--- a/src/migration/CompoundV3MigrationBundler.sol
+++ b/src/migration/CompoundV3MigrationBundler.sol
@@ -49,9 +49,8 @@ contract CompoundV3MigrationBundler is MigrationBundler {
     /// @dev Warning: `instance` can re-enter the bundler flow.
     /// @dev Assumes the given `instance` is a CompoundV3 instance.
     /// @param instance The address of the CompoundV3 instance to call.
-    /// @param asset The address of the token to withdraw from the CompoundV3 `instance`.
-    /// @param amount The amount of `asset` to withdraw the CompoundV3 `instance`. Pass `type(uint256).max` to withdraw
-    /// all.
+    /// @param asset The address of the token to withdraw.
+    /// @param amount The amount of `asset` to withdraw. Pass `type(uint256).max` to withdraw all.
     function compoundV3WithdrawFrom(address instance, address asset, uint256 amount) external payable {
         address initiator = initiator();
         uint256 balance = asset == ICompoundV3(instance).baseToken()

--- a/src/migration/CompoundV3MigrationBundler.sol
+++ b/src/migration/CompoundV3MigrationBundler.sol
@@ -22,6 +22,7 @@ contract CompoundV3MigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `asset` on the CompoundV3 `instance`, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice User must have transferred the needed amount of tokens before the execution.
     /// @dev Assumes the given instance is a CompoundV3 instance.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param instance The address of the CompoundV3 instance to call.

--- a/src/migration/CompoundV3MigrationBundler.sol
+++ b/src/migration/CompoundV3MigrationBundler.sol
@@ -40,6 +40,7 @@ contract CompoundV3MigrationBundler is MigrationBundler {
     }
 
     /// @notice Withdraws `amount` of `asset` on the CompoundV3 `instance`.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously transferred their CompoundV3 position to the bundler.
     /// @dev Assumes the given `instance` is a CompoundV3 instance.
     /// @dev Pass `amount = type(uint256).max` to withdraw all.
@@ -52,6 +53,7 @@ contract CompoundV3MigrationBundler is MigrationBundler {
 
     /// @notice Withdraws `amount` of `asset` from the CompoundV3 `instance`, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
+    /// @notice Withdrawn assets are received by the bundler and should be used afterwards.
     /// @dev Initiator must have previously approved the bundler to manage their CompoundV3 position.
     /// @dev Assumes the given `instance` is a CompoundV3 instance.
     /// @dev Pass `amount = type(uint256).max` to withdraw all.

--- a/src/migration/CompoundV3MigrationBundler.sol
+++ b/src/migration/CompoundV3MigrationBundler.sol
@@ -22,7 +22,7 @@ contract CompoundV3MigrationBundler is MigrationBundler {
 
     /// @notice Repays `amount` of `asset` on the CompoundV3 `instance`, on behalf of the initiator.
     /// @notice Warning: should only be called via the bundler's `multicall` function.
-    /// @notice User must have transferred the needed amount of tokens before the execution.
+    /// @dev Initiator must have previously transferred their assets to the bundler.
     /// @dev Assumes the given instance is a CompoundV3 instance.
     /// @dev Pass `amount = type(uint256).max` to repay all.
     /// @param instance The address of the CompoundV3 instance to call.


### PR DESCRIPTION
Fixes https://github.com/cantinasec/review-morpho-blue-1/issues/26

I didn't add such comments on AaveV3, AaveV2 and AaveV3Optimizer bundlers withdraw functions because `receiver` will be removed