### PR TITLE
fix(compound-v3): fix interface

### DIFF
--- a/src/migration/CompoundV3MigrationBundler.sol
+++ b/src/migration/CompoundV3MigrationBundler.sol
@@ -51,7 +51,7 @@ contract CompoundV3MigrationBundler is MigrationBundler {
         address _initiator = initiator();
         uint256 balance = asset == ICompoundV3(instance).baseToken()
             ? ICompoundV3(instance).balanceOf(_initiator)
-            : ICompoundV3(instance).userCollateral(_initiator, asset);
+            : ICompoundV3(instance).userCollateral(_initiator, asset).balance;
 
         amount = Math.min(amount, balance);
 

--- a/src/migration/interfaces/ICompoundV3.sol
+++ b/src/migration/interfaces/ICompoundV3.sol
@@ -15,6 +15,11 @@ struct Authorization {
     uint256 expiry;
 }
 
+struct UserCollateral {
+    uint128 balance;
+    uint128 _reserved;
+}
+
 interface ICompoundV3 {
     error BadSignatory();
 
@@ -24,7 +29,7 @@ interface ICompoundV3 {
 
     function baseToken() external view returns (address);
 
-    function userCollateral(address account, address asset) external view returns (uint256);
+    function userCollateral(address account, address asset) external view returns (UserCollateral memory);
 
     function balanceOf(address account) external view returns (uint256);
 


### PR DESCRIPTION
- Fixes https://cantina.xyz/code/8409a0ce-6c21-4cc9-8ef2-bd77ce7425af/findings/98b09f89-fe6d-4bd3-93e5-09940aeff12a

It was working because `_reserved` is `0` in production and stored left in the word so it was equivalent... Until `_reserved` is not zero