### PR TITLE
Imports go through public allocator

### DIFF
--- a/src/MorphoBundler.sol
+++ b/src/MorphoBundler.sol
@@ -2,16 +2,18 @@
 pragma solidity 0.8.24;
 
 import {IMorphoBundler} from "./interfaces/IMorphoBundler.sol";
-import {MarketParams, Signature, Authorization, IMorpho} from "../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {
+    IMorpho,
+    Id,
+    MarketParams,
+    Signature,
+    Authorization
+} from "../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IMorpho.sol";
 
 import {ErrorsLib} from "./libraries/ErrorsLib.sol";
 import {SafeTransferLib, ERC20} from "../lib/solmate/src/utils/SafeTransferLib.sol";
 
-import {
-    IPublicAllocator,
-    Withdrawal,
-    MarketParams as PublicAllocatorMarketParams
-} from "../lib/public-allocator/src/interfaces/IPublicAllocator.sol";
+import {IPublicAllocator, Withdrawal} from "../lib/public-allocator/src/interfaces/IPublicAllocator.sol";
 import {BaseBundler} from "./BaseBundler.sol";
 
 /// @title MorphoBundler
@@ -256,11 +258,7 @@ abstract contract MorphoBundler is BaseBundler, IMorphoBundler {
         Withdrawal[] calldata withdrawals,
         MarketParams calldata supplyMarketParams
     ) external payable protected {
-        PublicAllocatorMarketParams calldata pamp;
-        assembly {
-            pamp := supplyMarketParams
-        }
-        IPublicAllocator(publicAllocator).reallocateTo{value: value}(vault, withdrawals, pamp);
+        IPublicAllocator(publicAllocator).reallocateTo{value: value}(vault, withdrawals, supplyMarketParams);
     }
 
     /* INTERNAL */

--- a/src/interfaces/IMorphoBundler.sol
+++ b/src/interfaces/IMorphoBundler.sol
@@ -6,7 +6,7 @@ import {
     IMorphoSupplyCallback,
     IMorphoSupplyCollateralCallback,
     IMorphoFlashLoanCallback
-} from "../../lib/morpho-blue/src/interfaces/IMorphoCallbacks.sol";
+} from "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IMorphoCallbacks.sol";
 
 /// @title IMorphoBundler
 /// @author Morpho Labs

--- a/src/mocks/IrmMock.sol
+++ b/src/mocks/IrmMock.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IIrm} from "../../lib/morpho-blue/src/interfaces/IIrm.sol";
-import {MarketParams, Market} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {IIrm} from "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IIrm.sol";
+import {
+    MarketParams, Market
+} from "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IMorpho.sol";
 
-import {MathLib} from "../../lib/morpho-blue/src/libraries/MathLib.sol";
+import {MathLib} from "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/MathLib.sol";
 
 contract IrmMock is IIrm {
     using MathLib for uint128;

--- a/src/mocks/MorphoMock.sol
+++ b/src/mocks/MorphoMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {Morpho} from "../../lib/morpho-blue/src/Morpho.sol";
+import {Morpho} from "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/Morpho.sol";
 
 contract MorphoMock is Morpho {
     constructor(address owner) Morpho(owner) {}

--- a/src/mocks/OracleMock.sol
+++ b/src/mocks/OracleMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IOracle} from "../../lib/morpho-blue/src/interfaces/IOracle.sol";
+import {IOracle} from "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IOracle.sol";
 
 contract OracleMock is IOracle {
     uint256 public price;

--- a/test/forge/MorphoBundlerLocalTest.sol
+++ b/test/forge/MorphoBundlerLocalTest.sol
@@ -3,13 +3,9 @@ pragma solidity ^0.8.0;
 
 import {SigUtils} from "./helpers/SigUtils.sol";
 import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
-import {ErrorsLib as MorphoErrorsLib} from "../../lib/morpho-blue/src/libraries/ErrorsLib.sol";
-import {MarketParamsLib} from "../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
-import {
-    FlowCapsConfig,
-    MAX_SETTABLE_FLOW_CAP,
-    Id as PAId
-} from "../../lib/public-allocator/src/interfaces/IPublicAllocator.sol";
+import {ErrorsLib as MorphoErrorsLib} from
+    "../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/ErrorsLib.sol";
+import {FlowCapsConfig, MAX_SETTABLE_FLOW_CAP} from "../../lib/public-allocator/src/interfaces/IPublicAllocator.sol";
 
 import "../../src/mocks/bundlers/MorphoBundlerMock.sol";
 
@@ -660,9 +656,9 @@ contract MorphoBundlerLocalTest is VaultTest {
         maxOut = bound(maxOut, amount, MAX_SETTABLE_FLOW_CAP);
 
         FlowCapsConfig[] memory flows = new FlowCapsConfig[](2);
-        flows[0].id = PAId.wrap(Id.unwrap(marketParams.id()));
+        flows[0].id = marketParams.id();
         flows[0].caps.maxIn = uint128(maxIn);
-        flows[1].id = PAId.wrap(Id.unwrap(idleMarketParams.id()));
+        flows[1].id = idleMarketParams.id();
         flows[1].caps.maxOut = uint128(maxOut);
 
         vm.startPrank(VAULT_OWNER);
@@ -676,7 +672,7 @@ contract MorphoBundlerLocalTest is VaultTest {
         vault.deposit(amount, SUPPLIER);
 
         Withdrawal[] memory withdrawals = new Withdrawal[](1);
-        withdrawals[0].marketParams = convertParams(idleMarketParams);
+        withdrawals[0].marketParams = idleMarketParams;
         withdrawals[0].amount = uint128(amount);
         bundle.push(_reallocateTo(address(publicAllocator), address(vault), fee, withdrawals, marketParams));
 

--- a/test/forge/ethereum/migration/helpers/EthereumMigrationTest.sol
+++ b/test/forge/ethereum/migration/helpers/EthereumMigrationTest.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.0;
 
 import {SafeTransferLib, ERC20} from "../../../../../lib/solmate/src/utils/SafeTransferLib.sol";
 import {ErrorsLib} from "../../../../../src/libraries/ErrorsLib.sol";
-import {MarketParamsLib} from "../../../../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
-import {MorphoLib} from "../../../../../lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
-import {Market} from "../../../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
-import {MorphoBalancesLib} from "../../../../../lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
+import {MorphoLib} from
+    "../../../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
+import {Market} from "../../../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {MorphoBalancesLib} from
+    "../../../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
 
 import "../../helpers/EthereumTest.sol";
 import {BaseBundler} from "../../../../../src/BaseBundler.sol";

--- a/test/forge/helpers/BaseTest.sol
+++ b/test/forge/helpers/BaseTest.sol
@@ -1,31 +1,28 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {
-    IMorpho,
-    Id,
-    MarketParams,
-    Authorization as MorphoBlueAuthorization,
-    Signature as MorphoBlueSignature
-} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
 import {IPublicAllocatorBase} from "../../../lib/public-allocator/src/interfaces/IPublicAllocator.sol";
 
 import {SigUtils} from "./SigUtils.sol";
-import {MarketParamsLib} from "../../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
-import {SharesMathLib} from "../../../lib/morpho-blue/src/libraries/SharesMathLib.sol";
-import {MathLib, WAD} from "../../../lib/morpho-blue/src/libraries/MathLib.sol";
-import {UtilsLib} from "../../../lib/morpho-blue/src/libraries/UtilsLib.sol";
+import {MarketParamsLib} from
+    "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/MarketParamsLib.sol";
+import {SharesMathLib} from
+    "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/SharesMathLib.sol";
+import {MathLib, WAD} from "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/MathLib.sol";
+import {UtilsLib} from "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/UtilsLib.sol";
 import {SafeTransferLib, ERC20} from "../../../lib/solmate/src/utils/SafeTransferLib.sol";
-import {MorphoLib} from "../../../lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
-import {MorphoBalancesLib} from "../../../lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
+import {MorphoLib} from
+    "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
+import {MorphoBalancesLib} from
+    "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
 import {
     LIQUIDATION_CURSOR,
     MAX_LIQUIDATION_INCENTIVE_FACTOR,
     ORACLE_PRICE_SCALE
-} from "../../../lib/morpho-blue/src/libraries/ConstantsLib.sol";
+} from "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/ConstantsLib.sol";
 
-import {IrmMock} from "../../../lib/morpho-blue/src/mocks/IrmMock.sol";
-import {OracleMock} from "../../../lib/morpho-blue/src/mocks/OracleMock.sol";
+import {IrmMock} from "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/mocks/IrmMock.sol";
+import {OracleMock} from "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/mocks/OracleMock.sol";
 
 import {BaseBundler} from "../../../src/BaseBundler.sol";
 import {TransferBundler} from "../../../src/TransferBundler.sol";
@@ -189,7 +186,7 @@ abstract contract BaseTest is Test {
     {
         address user = vm.addr(privateKey);
 
-        MorphoBlueAuthorization memory authorization = MorphoBlueAuthorization({
+        Authorization memory authorization = Authorization({
             authorizer: user,
             authorized: address(bundler),
             isAuthorized: isAuthorized,
@@ -199,7 +196,7 @@ abstract contract BaseTest is Test {
 
         bytes32 digest = SigUtils.toTypedDataHash(morpho.DOMAIN_SEPARATOR(), authorization);
 
-        MorphoBlueSignature memory signature;
+        Signature memory signature;
         (signature.v, signature.r, signature.s) = vm.sign(privateKey, digest);
 
         return abi.encodeCall(MorphoBundler.morphoSetAuthorizationWithSig, (authorization, signature, skipRevert));

--- a/test/forge/helpers/LocalTest.sol
+++ b/test/forge/helpers/LocalTest.sol
@@ -25,8 +25,10 @@ abstract contract LocalTest is BaseTest {
         loanToken = new ERC20Mock("loan", "B");
         collateralToken = new ERC20Mock("collateral", "C");
 
-        marketParams = MarketParams(address(loanToken), address(collateralToken), address(oracle), address(irm), LLTV);
-        id = marketParams.id();
+        MarketParams memory mp =
+            MarketParams(address(loanToken), address(collateralToken), address(oracle), address(irm), LLTV);
+        marketParams = mp;
+        id = mp.id();
 
         vm.startPrank(OWNER);
         morpho.enableLltv(LLTV);

--- a/test/forge/helpers/LocalTest.sol
+++ b/test/forge/helpers/LocalTest.sol
@@ -25,10 +25,8 @@ abstract contract LocalTest is BaseTest {
         loanToken = new ERC20Mock("loan", "B");
         collateralToken = new ERC20Mock("collateral", "C");
 
-        MarketParams memory mp =
-            MarketParams(address(loanToken), address(collateralToken), address(oracle), address(irm), LLTV);
-        marketParams = mp;
-        id = mp.id();
+        marketParams = MarketParams(address(loanToken), address(collateralToken), address(oracle), address(irm), LLTV);
+        id = marketParams.id();
 
         vm.startPrank(OWNER);
         morpho.enableLltv(LLTV);

--- a/test/forge/helpers/SigUtils.sol
+++ b/test/forge/helpers/SigUtils.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {ICompoundV3} from "../../../src/migration/interfaces/ICompoundV3.sol";
-import {Authorization} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {Authorization} from "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/interfaces/IMorpho.sol";
 import {IAllowanceTransfer} from "../../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
 import {
     Authorization as AaveV3OptimizerAuthorization,
@@ -16,7 +16,8 @@ import {
 
 import {PermitHash} from "../../../lib/permit2/src/libraries/PermitHash.sol";
 import {ECDSA} from "../../../lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
-import {AUTHORIZATION_TYPEHASH} from "../../../lib/morpho-blue/src/libraries/ConstantsLib.sol";
+import {AUTHORIZATION_TYPEHASH} from
+    "../../../lib/public-allocator/lib/metamorpho/lib/morpho-blue/src/libraries/ConstantsLib.sol";
 
 bytes32 constant PERMIT_TYPEHASH =
     keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");

--- a/test/forge/helpers/VaultTest.sol
+++ b/test/forge/helpers/VaultTest.sol
@@ -53,16 +53,4 @@ abstract contract VaultTest is LocalTest {
         vault.acceptCap(marketParams);
         vm.stopPrank();
     }
-
-    function convertParams(MarketParams memory marketParams)
-        internal
-        pure
-        returns (PublicAllocatorMarketParams memory mp)
-    {
-        mp.loanToken = marketParams.loanToken;
-        mp.collateralToken = marketParams.collateralToken;
-        mp.lltv = marketParams.lltv;
-        mp.irm = marketParams.irm;
-        mp.oracle = marketParams.oracle;
-    }
 }


### PR DESCRIPTION
This allows to not have a conversion issue with the reallocateTo function's parameters