### PR TITLE
doc: correct CALL_FAILED description

### DIFF
--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -29,7 +29,7 @@ library ErrorsLib {
     /// @dev Thrown when a call is attempted with a zero shares as input.
     string internal constant ZERO_SHARES = "zero shares";
 
-    /// @dev Thrown when a call reverts with empty returndata.
+    /// @dev Thrown when a call reverts with empty `returnData`.
     string internal constant CALL_FAILED = "call failed";
 
     /// @dev Thrown when the given owner is unexpected.

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -29,7 +29,7 @@ library ErrorsLib {
     /// @dev Thrown when a call is attempted with a zero shares as input.
     string internal constant ZERO_SHARES = "zero shares";
 
-    /// @dev Thrown when a call reverted and wasn't allowed to revert.
+    /// @dev Thrown when a call reverts with empty returndata.
     string internal constant CALL_FAILED = "call failed";
 
     /// @dev Thrown when the given owner is unexpected.


### PR DESCRIPTION
Error description did not match usage. The error is used when trying to bubble up a failed called but the call has empty returndata. In that case, CALL_FAILED is thrown.

The description in `ErrorsLib.sol` did not correctly describe when CALL_FAILED was used.