### PR TITLE
feat: bundler can have modules

### DIFF
--- a/src/ModuleCallerBundler.sol
+++ b/src/ModuleCallerBundler.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.24;
+
+import {IMorphoBundlerModule} from "./interfaces/IMorphoBundlerModule.sol";
+import {BaseBundler} from "./BaseBundler.sol";
+
+/// @title ModuleCallerBundler
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Bundler contract managing calls to external bundler module contracts
+abstract contract ModuleCallerBundler is BaseBundler {
+    /// @notice Calls `module`, passing along `data` and the current `initiator`.
+    function callModule(address module, bytes calldata data) external payable protected {
+        IMorphoBundlerModule(module).morphoBundlerModuleCall(initiator(), data);
+    }
+}

--- a/src/chain-agnostic/ChainAgnosticBundlerV2.sol
+++ b/src/chain-agnostic/ChainAgnosticBundlerV2.sol
@@ -10,6 +10,7 @@ import {WNativeBundler} from "../WNativeBundler.sol";
 import {UrdBundler} from "../UrdBundler.sol";
 import {MorphoBundler} from "../MorphoBundler.sol";
 import {ERC20WrapperBundler} from "../ERC20WrapperBundler.sol";
+import {ModuleCallerBundler} from "../ModuleCallerBundler.sol";
 
 /// @title ChainAgnosticBundlerV2
 /// @author Morpho Labs
@@ -23,7 +24,8 @@ contract ChainAgnosticBundlerV2 is
     WNativeBundler,
     UrdBundler,
     MorphoBundler,
-    ERC20WrapperBundler
+    ERC20WrapperBundler,
+    ModuleCallerBundler
 {
     /* CONSTRUCTOR */
 

--- a/src/ethereum/EthereumBundlerV2.sol
+++ b/src/ethereum/EthereumBundlerV2.sol
@@ -13,6 +13,7 @@ import {EthereumStEthBundler} from "./EthereumStEthBundler.sol";
 import {UrdBundler} from "../UrdBundler.sol";
 import {MorphoBundler} from "../MorphoBundler.sol";
 import {ERC20WrapperBundler} from "../ERC20WrapperBundler.sol";
+import {ModuleCallerBundler} from "../ModuleCallerBundler.sol";
 
 /// @title EthereumBundlerV2
 /// @author Morpho Labs
@@ -27,7 +28,8 @@ contract EthereumBundlerV2 is
     EthereumStEthBundler,
     UrdBundler,
     MorphoBundler,
-    ERC20WrapperBundler
+    ERC20WrapperBundler,
+    ModuleCallerBundler
 {
     /* CONSTRUCTOR */
 

--- a/src/goerli/GoerliBundlerV2.sol
+++ b/src/goerli/GoerliBundlerV2.sol
@@ -13,6 +13,7 @@ import {StEthBundler} from "../StEthBundler.sol";
 import {UrdBundler} from "../UrdBundler.sol";
 import {MorphoBundler} from "../MorphoBundler.sol";
 import {ERC20WrapperBundler} from "../ERC20WrapperBundler.sol";
+import {ModuleCallerBundler} from "../ModuleCallerBundler.sol";
 
 /// @title GoerliBundlerV2
 /// @author Morpho Labs
@@ -27,7 +28,8 @@ contract GoerliBundlerV2 is
     StEthBundler,
     UrdBundler,
     MorphoBundler,
-    ERC20WrapperBundler
+    ERC20WrapperBundler,
+    ModuleCallerBundler
 {
     /* CONSTRUCTOR */
 

--- a/src/interfaces/IMorphoBundlerModule.sol
+++ b/src/interfaces/IMorphoBundlerModule.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title IMorphoBundler
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Interface of Morpho Bundler module.
+interface IMorphoBundlerModule {
+    /// @notice Receives a call from the Morpho Bundler.
+    function morphoBundlerModuleCall(address initiator, bytes calldata data) external payable;
+}

--- a/src/mocks/MorphoBundlerModuleMock.sol
+++ b/src/mocks/MorphoBundlerModuleMock.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {BaseMorphoBundlerModule} from "../modules/BaseMorphoBundlerModule.sol";
+
+contract MorphoBundlerModuleMock is BaseMorphoBundlerModule {
+    constructor(address bundler) BaseMorphoBundlerModule(bundler) {}
+
+    function _morphoBundlerModuleCall(address, bytes calldata) internal override {}
+}

--- a/src/modules/BaseMorphoBundlerModule.sol
+++ b/src/modules/BaseMorphoBundlerModule.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import {ErrorsLib} from "../libraries/ErrorsLib.sol";
+import {IMorphoBundlerModule} from "../interfaces/IMorphoBundlerModule.sol";
+
+/// @title BaseMorphoBundlerModule
+/// @author Morpho Labs
+/// @custom:contact security@morpho.org
+/// @notice Morpho Bundler Module abstract contract. Enforces caller verification.
+abstract contract BaseMorphoBundlerModule is IMorphoBundlerModule {
+    address public immutable MORPHO_BUNDLER;
+
+    constructor(address morphoBundler) {
+        MORPHO_BUNDLER = morphoBundler;
+    }
+
+    /// @notice Wrapper that receives call from the Morpho Bundler.
+    /// @dev Checks that msg.sender is the Morpho Bundler so that initiator value can be trusted.
+    function morphoBundlerModuleCall(address initiator, bytes calldata data) external payable {
+        require(msg.sender == MORPHO_BUNDLER, ErrorsLib.UNAUTHORIZED_SENDER);
+        _morphoBundlerModuleCall(initiator, data);
+    }
+
+    /// @notice Receives a call from the Morpho Bundler.
+    /// @dev Must be implemented by inheriting contracts.
+    function _morphoBundlerModuleCall(address initiator, bytes calldata data) internal virtual;
+}

--- a/test/forge/BaseMorphoBundlerModuleTest.sol
+++ b/test/forge/BaseMorphoBundlerModuleTest.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
+
+import {ModuleCallerBundler} from "../../src/ModuleCallerBundler.sol";
+import {IMorphoBundlerModule} from "../../src/interfaces/IMorphoBundlerModule.sol";
+
+import "./helpers/LocalTest.sol";
+import {MorphoBundlerModuleMock} from "../../src/mocks/MorphoBundlerModuleMock.sol";
+
+contract BaseMorphoBundlerModuleTest is LocalTest {
+    function testCheckCallerSuccess(address bundlerAddress) public {
+        MorphoBundlerModuleMock mock = new MorphoBundlerModuleMock(bundlerAddress);
+
+        bundle.push(abi.encodeCall(ModuleCallerBundler.callModule, (address(mock), hex"")));
+
+        vm.prank(bundlerAddress);
+        mock.morphoBundlerModuleCall(address(0), hex"");
+    }
+
+    function testCheckCallerFailure(address correctAddress, address wrongAddress) public {
+        vm.assume(correctAddress != wrongAddress);
+        MorphoBundlerModuleMock mock = new MorphoBundlerModuleMock(correctAddress);
+
+        vm.prank(wrongAddress);
+        vm.expectRevert(bytes(ErrorsLib.UNAUTHORIZED_SENDER));
+        mock.morphoBundlerModuleCall(address(0), hex"");
+    }
+}

--- a/test/forge/ModuleCallerBundlerTest.sol
+++ b/test/forge/ModuleCallerBundlerTest.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
+
+import {ModuleCallerBundler} from "../../src/ModuleCallerBundler.sol";
+import {IMorphoBundlerModule} from "../../src/interfaces/IMorphoBundlerModule.sol";
+
+import "./helpers/LocalTest.sol";
+
+contract ModuleCallerBundlerTest is LocalTest {
+    function testPassthroughInitiator(address initiator) public {
+        vm.mockCall(address(0), bytes.concat(IMorphoBundlerModule.morphoBundlerModuleCall.selector), hex"");
+
+        bundle.push(abi.encodeCall(ModuleCallerBundler.callModule, (address(0), hex"")));
+
+        vm.prank(initiator);
+        bundler.multicall(bundle);
+    }
+}


### PR DESCRIPTION
Modules are called using the bundler's new `callModule(address module, bytes data)` function. No onchain whitelist of module addresses is needed, and users should only approve modules they use.

When called, a bundler module receives the current `initiator` and the `data` argument. A module contract should inherit `BaseMorphoBundlerModule` and implement the internal function `_morphoBundlerModuleCall`. It is wrapped in an external function `morphoBundlerModuleCall` that checks the caller. So modules can trust that the `initiator` is correct.

Some alternatives:
- Remove `BaseMorphoBundlerModule`. Keep only the `IMorphoBundlerModule` interface and document that all implementations should check the caller. But it's more error-prone vs. the inheritance of `BaseMorphoBundlerModule` which is not heavy.
- Remove the caller check and the initiator argument, have modules call `bundler.initiator()` if they want to know the initiator. But it costs more gas.

Note: The signature of `morphoBundlerModuleCall(address initiator, bytes calldata data)` is `0xd26db89e` and does not appear in [4byte.directory](https://www.4byte.directory/).