### PR TITLE
Run StEth fork test by default

### DIFF
--- a/test/forge/fork/StEthBundlerForkTest.sol
+++ b/test/forge/fork/StEthBundlerForkTest.sol
@@ -17,9 +17,9 @@ contract EthereumStEthBundlerForkTest is ForkTest {
     using SafeTransferLib for ERC20;
 
     function setUp() public override {
-        if (block.chainid != 1) return;
-
         super.setUp();
+
+        if (block.chainid != 1) return;
 
         bundler = new EthereumStEthBundlerMock();
     }

--- a/test/forge/fork/migration/AaveV2MigrationBundlerForkTest.sol
+++ b/test/forge/fork/migration/AaveV2MigrationBundlerForkTest.sol
@@ -21,9 +21,9 @@ contract AaveV2MigrationBundlerForkTest is MigrationForkTest {
     uint256 borrowed = 1 ether;
 
     function setUp() public override {
-        if (block.chainid != 1) return;
-
         super.setUp();
+
+        if (block.chainid != 1) return;
 
         _initMarket(DAI, WETH);
 

--- a/test/forge/fork/migration/CompoundV2EthBorrowableMigrationBundlerForkTest.sol
+++ b/test/forge/fork/migration/CompoundV2EthBorrowableMigrationBundlerForkTest.sol
@@ -17,9 +17,9 @@ contract CompoundV2EthLoanMigrationBundlerForkTest is MigrationForkTest {
     address[] internal enteredMarkets;
 
     function setUp() public override {
-        if (block.chainid != 1) return;
-
         super.setUp();
+
+        if (block.chainid != 1) return;
 
         _initMarket(DAI, WETH);
 

--- a/test/forge/fork/migration/CompoundV2EthCollateralMigrationBundlerForkTest.sol
+++ b/test/forge/fork/migration/CompoundV2EthCollateralMigrationBundlerForkTest.sol
@@ -17,9 +17,9 @@ contract CompoundV2EthCollateralMigrationBundlerForkTest is MigrationForkTest {
     address[] internal enteredMarkets;
 
     function setUp() public override {
-        if (block.chainid != 1) return;
-
         super.setUp();
+
+        if (block.chainid != 1) return;
 
         _initMarket(WETH, DAI);
 

--- a/test/forge/fork/migration/CompoundV2NoEthMigrationBundlerForkTest.sol
+++ b/test/forge/fork/migration/CompoundV2NoEthMigrationBundlerForkTest.sol
@@ -17,9 +17,9 @@ contract CompoundV2NoEthMigrationBundlerForkTest is MigrationForkTest {
     address[] internal enteredMarkets;
 
     function setUp() public override {
-        if (block.chainid != 1) return;
-
         super.setUp();
+
+        if (block.chainid != 1) return;
 
         _initMarket(DAI, USDC);
 


### PR DESCRIPTION
When running `forge test`, the parent contract of fork tests named `ForkTest` sets the chain id to 1 by default in its `setUp` functon. All fork tests except one thus run on Ethereum. 

`EthereumStEthBundlerForkTest` does not, because it skips `ForkTest`'s `setUp` if the chain id is not 1, and all its tests are skipped if the chain id is not 1.

This PR makes the tests of `EthereumStEthBundlerForkTest` run by default.