### PR TITLE
Check non-view non-multicall functions are protected

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -1,0 +1,49 @@
+name: Certora
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        conf:
+          - AaveV2MigrationBundlerV2
+          - AaveV3MigrationBundlerV2
+          - AaveV3OptimizerMigrationBundlerV2
+          - ChainAgnosticBundlerV2
+          - CompoundV2MigrationBundlerV2
+          - CompoundV3MigrationBundlerV2
+          - EthereumBundlerV2
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ">=3.11"
+
+      - name: Install certora
+        run: pip install certora-cli
+
+      - name: Install solc (0.8.24)
+        run: |
+          wget https://github.com/ethereum/solidity/releases/download/v0.8.24/solc-static-linux
+          chmod +x solc-static-linux
+          sudo mv solc-static-linux /usr/local/bin/solc-0.8.24
+
+      - name: Verify ${{ matrix.conf }} specification
+        run: certoraRun certora/confs/${{ matrix.conf }}.conf
+        env:
+          CERTORAKEY: ${{ secrets.CERTORAKEY }}

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           wget https://github.com/ethereum/solidity/releases/download/v0.8.24/solc-static-linux
           chmod +x solc-static-linux
-          sudo mv solc-static-linux /usr/local/bin/solc-0.8.24
+          sudo mv solc-static-linux /usr/local/bin/solc
 
       - name: Verify ${{ matrix.conf }} specification
         run: certoraRun certora/confs/${{ matrix.conf }}.conf

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           wget https://github.com/ethereum/solidity/releases/download/v0.8.24/solc-static-linux
           chmod +x solc-static-linux
-          sudo mv solc-static-linux /usr/local/bin/solc
+          sudo mv solc-static-linux /usr/local/bin/solc-0.8.24
 
       - name: Verify ${{ matrix.conf }} specification
         run: certoraRun certora/confs/${{ matrix.conf }}.conf

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ node_modules/
 /artifacts
 
 *.log
+
+# Certora
+.certora_internal

--- a/certora/README.md
+++ b/certora/README.md
@@ -1,0 +1,35 @@
+# Bundlers Formal Verification
+
+This folder contains the [CVL](https://docs.certora.com/en/latest/docs/cvl/index.html) specification and verification setup for the following bundler contracts:
+
+- [AaveV2MigrationBundlerV2](../src/migration/AaveV2MigrationBundlerV2.sol)
+- [AaveV3MigrationBundlerV2](../src/migration/AaveV3MigrationBundlerV2.sol)
+- [AaveV3OptimizerMigrationBundlerV2](../src/migration/AaveV3OptimizerMigrationBundlerV2.sol)
+- [ChainAgnosticBundlerV2](../src/chain-agnostic/ChainAgnosticBundlerV2.sol)
+- [CompoundV2MigrationBundlerV2](../src/migration/CompoundV2MigrationBundlerV2.sol)
+- [CompoundV3MigrationBundlerV2](../src/migration/CompoundV3MigrationBundlerV2.sol)
+- [EthereumBundlerV2](../src/ethereum/EthereumBundlerV2.sol)
+
+## Getting Started
+
+To verify a specification, run the command `certoraRun Spec.conf` where `Spec.conf` is one of the configuration files in [`certora/confs`](confs).
+
+You must have set the `CERTORAKEY` environment variable to a valid Certora key.
+
+## Overview
+
+Bundler methods used during a bundle execution have the `protected` modifier. This modifier ensures that:
+- An initiator has been set, and
+- the caller is the bundle initiator or the Morpho contract.
+
+The `Protected.spec` file checks that all bundler functions, except noted exceptions, respect the requirements of the `protected` modifier when an initiator has been set.
+
+## Verification architecture
+
+### Folders and file structure
+
+The [`certora/specs`](specs) folder contains the following files:
+
+- [`Protected.spec`](specs/Protected.spec) checks that all methods except noted exceptions respect the `protected` modifier when an initiator has been set.
+
+The [`certora/confs`](confs) folder contains a configuration file for each deployed bundler.

--- a/certora/README.md
+++ b/certora/README.md
@@ -1,4 +1,4 @@
-# Bundlers Formal Verification
+# Bundlers formal verification
 
 This folder contains the [CVL](https://docs.certora.com/en/latest/docs/cvl/index.html) specification and verification setup for the following bundler contracts:
 

--- a/certora/README.md
+++ b/certora/README.md
@@ -10,7 +10,7 @@ This folder contains the [CVL](https://docs.certora.com/en/latest/docs/cvl/index
 - [CompoundV3MigrationBundlerV2](../src/migration/CompoundV3MigrationBundlerV2.sol)
 - [EthereumBundlerV2](../src/ethereum/EthereumBundlerV2.sol)
 
-## Getting Started
+## Getting started
 
 To verify a specification, run the command `certoraRun Spec.conf` where `Spec.conf` is one of the configuration files in [`certora/confs`](confs).
 
@@ -19,7 +19,7 @@ You must have set the `CERTORAKEY` environment variable to a valid Certora key.
 ## Overview
 
 Bundler methods used during a bundle execution have the `protected` modifier. This modifier ensures that:
-- An initiator has been set, and
+- an initiator has been set;
 - the caller is the bundle initiator or the Morpho contract.
 
 The `Protected.spec` file checks that all bundler functions, except noted exceptions, respect the requirements of the `protected` modifier when an initiator has been set.

--- a/certora/confs/AaveV2MigrationBundlerV2.conf
+++ b/certora/confs/AaveV2MigrationBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/migration/AaveV2MigrationBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/migration/AaveV2MigrationBundlerV2.sol"
   ],
   "verify": "AaveV2MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/AaveV2MigrationBundlerV2.conf
+++ b/certora/confs/AaveV2MigrationBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/migration/AaveV2MigrationBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "AaveV2MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/AaveV2MigrationBundlerV2.conf
+++ b/certora/confs/AaveV2MigrationBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/migration/AaveV2MigrationBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "AaveV2MigrationBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Aave V2 Migration Bundler V2 protected functions"
+}

--- a/certora/confs/AaveV3MigrationBundlerV2.conf
+++ b/certora/confs/AaveV3MigrationBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/migration/AaveV3MigrationBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/migration/AaveV3MigrationBundlerV2.sol"
   ],
   "verify": "AaveV3MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/AaveV3MigrationBundlerV2.conf
+++ b/certora/confs/AaveV3MigrationBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/migration/AaveV3MigrationBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "AaveV3MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/AaveV3MigrationBundlerV2.conf
+++ b/certora/confs/AaveV3MigrationBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/migration/AaveV3MigrationBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "AaveV3MigrationBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Aave V3 Migration Bundler V2 protected functions"
+}

--- a/certora/confs/AaveV3OptimizerMigrationBundlerV2.conf
+++ b/certora/confs/AaveV3OptimizerMigrationBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/migration/AaveV3OptimizerMigrationBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "AaveV3OptimizerMigrationBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Aave V3 Optimizer Migration Bundler V2 protected functions"
+}

--- a/certora/confs/AaveV3OptimizerMigrationBundlerV2.conf
+++ b/certora/confs/AaveV3OptimizerMigrationBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/migration/AaveV3OptimizerMigrationBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "AaveV3OptimizerMigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/AaveV3OptimizerMigrationBundlerV2.conf
+++ b/certora/confs/AaveV3OptimizerMigrationBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/migration/AaveV3OptimizerMigrationBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/migration/AaveV3OptimizerMigrationBundlerV2.sol"
   ],
   "verify": "AaveV3OptimizerMigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/ChainAgnosticBundlerV2.conf
+++ b/certora/confs/ChainAgnosticBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/chain-agnostic/ChainAgnosticBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/chain-agnostic/ChainAgnosticBundlerV2.sol"
   ],
   "verify": "ChainAgnosticBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/ChainAgnosticBundlerV2.conf
+++ b/certora/confs/ChainAgnosticBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/chain-agnostic/ChainAgnosticBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "ChainAgnosticBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/ChainAgnosticBundlerV2.conf
+++ b/certora/confs/ChainAgnosticBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/chain-agnostic/ChainAgnosticBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "ChainAgnosticBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Chain Agnostic Bundler V2 protected functions"
+}

--- a/certora/confs/CompoundV2MigrationBundlerV2.conf
+++ b/certora/confs/CompoundV2MigrationBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/migration/CompoundV2MigrationBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "CompoundV2MigrationBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Compound V2 Migration Bundler V2 protected functions"
+}

--- a/certora/confs/CompoundV2MigrationBundlerV2.conf
+++ b/certora/confs/CompoundV2MigrationBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/migration/CompoundV2MigrationBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "CompoundV2MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/CompoundV2MigrationBundlerV2.conf
+++ b/certora/confs/CompoundV2MigrationBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/migration/CompoundV2MigrationBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/migration/CompoundV2MigrationBundlerV2.sol"
   ],
   "verify": "CompoundV2MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/CompoundV3MigrationBundlerV2.conf
+++ b/certora/confs/CompoundV3MigrationBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/migration/CompoundV3MigrationBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "CompoundV3MigrationBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Compound V3 Migration Bundler V2 protected functions"
+}

--- a/certora/confs/CompoundV3MigrationBundlerV2.conf
+++ b/certora/confs/CompoundV3MigrationBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/migration/CompoundV3MigrationBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/migration/CompoundV3MigrationBundlerV2.sol"
   ],
   "verify": "CompoundV3MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/CompoundV3MigrationBundlerV2.conf
+++ b/certora/confs/CompoundV3MigrationBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/migration/CompoundV3MigrationBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "CompoundV3MigrationBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/EthereumBundlerV2.conf
+++ b/certora/confs/EthereumBundlerV2.conf
@@ -2,6 +2,7 @@
   "files": [
     "src/ethereum/EthereumBundlerV2.sol"
   ],
+  "solc": "solc-0.8.24",
   "verify": "EthereumBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/EthereumBundlerV2.conf
+++ b/certora/confs/EthereumBundlerV2.conf
@@ -1,7 +1,6 @@
 {
   "files": [
-    "src/ethereum/EthereumBundlerV2.sol",
-    "certora/harness/Constants.sol"
+    "src/ethereum/EthereumBundlerV2.sol"
   ],
   "verify": "EthereumBundlerV2:certora/specs/Protected.spec",
   "rule_sanity": "basic",

--- a/certora/confs/EthereumBundlerV2.conf
+++ b/certora/confs/EthereumBundlerV2.conf
@@ -1,0 +1,10 @@
+{
+  "files": [
+    "src/ethereum/EthereumBundlerV2.sol",
+    "certora/harness/Constants.sol"
+  ],
+  "verify": "EthereumBundlerV2:certora/specs/Protected.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Ethereum Bundler V2 protected functions"
+}

--- a/certora/harness/Constants.sol
+++ b/certora/harness/Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.24;
+
+import "../../src/libraries/ConstantsLib.sol" as ConstantsLib;
+
+contract Constants {
+    address public constant UNSET_INITIATOR = ConstantsLib.UNSET_INITIATOR;
+}

--- a/certora/harness/Constants.sol
+++ b/certora/harness/Constants.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.24;
-
-import "../../src/libraries/ConstantsLib.sol" as ConstantsLib;
-
-contract Constants {
-    address public constant UNSET_INITIATOR = ConstantsLib.UNSET_INITIATOR;
-}

--- a/certora/specs/Protected.spec
+++ b/certora/specs/Protected.spec
@@ -13,8 +13,7 @@ rule protectedWithSetInitiator(method f, env e, calldataarg data) filtered {
     f -> !f.isView && !f.isFallback && f.selector != sig:multicall(bytes[]).selector
 }
 {
-    require e.msg.sender != initiator();
-    require e.msg.sender != MORPHO();
     f@withrevert(e,data);
-    assert lastReverted;
+    bool reverted = lastReverted;
+    assert e.msg.sender != initiator() && e.msg.sender != MORPHO() => reverted;
 }

--- a/certora/specs/Protected.spec
+++ b/certora/specs/Protected.spec
@@ -8,7 +8,11 @@ methods {
 }
 
 
-rule protectedMethodsComplete(method f, env e, calldataarg data) filtered {
+// Check that all methods except those noted below comply with the `protected` modifier when an initiator has been set.
+rule protectedWithSetInitiator(method f, env e, calldataarg data) filtered {
+    // Do not check view functions.
+    // Do not check the fallback function.
+    // Do not check multicall, which is used to start a new bundle.
     f -> !f.isView && !f.isFallback && f.selector != sig:multicall(bytes[]).selector
 }
 {

--- a/certora/specs/Protected.spec
+++ b/certora/specs/Protected.spec
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-using Constants as constants;
-
 methods {
     function initiator() external returns(address) envfree;
     function MORPHO() external returns(address) envfree;
-    function constants.UNSET_INITIATOR() external returns(address) envfree;
 }
 
 
@@ -16,7 +13,6 @@ rule protectedWithSetInitiator(method f, env e, calldataarg data) filtered {
     f -> !f.isView && !f.isFallback && f.selector != sig:multicall(bytes[]).selector
 }
 {
-    require e.msg.sender != constants.UNSET_INITIATOR();
     require e.msg.sender != initiator();
     require e.msg.sender != MORPHO();
     f@withrevert(e,data);

--- a/certora/specs/Protected.spec
+++ b/certora/specs/Protected.spec
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+using Constants as constants;
+
+methods {
+    function initiator() external returns(address) envfree;
+    function MORPHO() external returns(address) envfree;
+    function constants.UNSET_INITIATOR() external returns(address) envfree;
+}
+
+
+rule protectedMethodsComplete(method f, env e, calldataarg data) filtered {
+    f -> !f.isView && !f.isFallback && f.selector != sig:multicall(bytes[]).selector
+}
+{
+    require e.msg.sender != constants.UNSET_INITIATOR();
+    require e.msg.sender != initiator();
+    require e.msg.sender != MORPHO();
+    f@withrevert(e,data);
+    assert lastReverted;
+}

--- a/certora/specs/Protected.spec
+++ b/certora/specs/Protected.spec
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-methods {
-    function initiator() external returns(address) envfree;
-    function MORPHO() external returns(address) envfree;
-}
-
 
 // Check that all methods except those noted below comply with the `protected` modifier when an initiator has been set.
 rule protectedWithSetInitiator(method f, env e, calldataarg data) filtered {
     // Do not check view functions.
+    f -> !f.isView &&
     // Do not check the fallback function.
+    !f.isFallback &&
     // Do not check multicall, which is used to start a new bundle.
-    f -> !f.isView && !f.isFallback && f.selector != sig:multicall(bytes[]).selector
+    f.selector != sig:multicall(bytes[]).selector
 }
 {
+    // Safe require because `protected` functions should be callable by the initiator.
+    require e.msg.sender != currentContract._initiator;
+    // Safe require because `protected` functions should be callable by Morpho.
+    require e.msg.sender != currentContract.MORPHO;
     f@withrevert(e,data);
-    bool reverted = lastReverted;
-    assert e.msg.sender != initiator() && e.msg.sender != MORPHO() => reverted;
+    assert lastReverted;
 }


### PR DESCRIPTION
Bundler methods used during a bundle execution have the `protected` modifier. This modifier ensures that:
- An initiator has been set, and
- the caller is the bundle initiator or the Morpho contract.

The `Protected.spec` file checks that all bundler functions, except noted exceptions, respect the requirements of the `protected` modifier when an initiator has been set.