### PR TITLE
Fix leftover paths and pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint
+yarn lint:check

--- a/test/fork/BundlerForkTest.sol
+++ b/test/fork/BundlerForkTest.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IAllowanceTransfer} from "../../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
+import {IAllowanceTransfer} from "../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
 
-import {EthereumBundlerV2} from "../../../src/ethereum/EthereumBundlerV2.sol";
-import {ChainAgnosticBundlerV2} from "../../../src/chain-agnostic/ChainAgnosticBundlerV2.sol";
+import {EthereumBundlerV2} from "../../src/ethereum/EthereumBundlerV2.sol";
+import {ChainAgnosticBundlerV2} from "../../src/chain-agnostic/ChainAgnosticBundlerV2.sol";
 
 import "./helpers/ForkTest.sol";
 

--- a/test/fork/Permit2BundlerForkTest.sol
+++ b/test/fork/Permit2BundlerForkTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
 
 import "./helpers/ForkTest.sol";
 

--- a/test/fork/PermitBundlerForkTest.sol
+++ b/test/fork/PermitBundlerForkTest.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
 
 import {DaiPermit, Permit} from "../helpers/SigUtils.sol";
 
-import "../../../src/ethereum/EthereumPermitBundler.sol";
-import {IERC20Permit} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
-import {ERC20PermitMock} from "../../../src/mocks/ERC20PermitMock.sol";
+import "../../src/ethereum/EthereumPermitBundler.sol";
+import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import {ERC20PermitMock} from "../../src/mocks/ERC20PermitMock.sol";
 
 import "./helpers/ForkTest.sol";
 

--- a/test/fork/StEthBundlerForkTest.sol
+++ b/test/fork/StEthBundlerForkTest.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IAllowanceTransfer} from "../../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
+import {IAllowanceTransfer} from "../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
 
-import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
 
-import "../../../src/ethereum/EthereumStEthBundler.sol";
+import "../../src/ethereum/EthereumStEthBundler.sol";
 
 import "./helpers/ForkTest.sol";
 

--- a/test/fork/WNativeBundlerForkTest.sol
+++ b/test/fork/WNativeBundlerForkTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {ErrorsLib} from "../../../src/libraries/ErrorsLib.sol";
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
 
 import "./helpers/ForkTest.sol";
 

--- a/test/fork/helpers/ForkTest.sol
+++ b/test/fork/helpers/ForkTest.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import {IStEth} from "../../../../src/interfaces/IStEth.sol";
-import {IWstEth} from "../../../../src/interfaces/IWstEth.sol";
-import {IAllowanceTransfer} from "../../../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
+import {IStEth} from "../../../src/interfaces/IStEth.sol";
+import {IWstEth} from "../../../src/interfaces/IWstEth.sol";
+import {IAllowanceTransfer} from "../../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
 
-import {Permit2Lib} from "../../../../lib/permit2/src/libraries/Permit2Lib.sol";
+import {Permit2Lib} from "../../../lib/permit2/src/libraries/Permit2Lib.sol";
 
-import {Permit2Bundler} from "../../../../src/Permit2Bundler.sol";
-import {WNativeBundler} from "../../../../src/WNativeBundler.sol";
-import {StEthBundler} from "../../../../src/StEthBundler.sol";
-import {EthereumBundlerV2} from "../../../../src/ethereum/EthereumBundlerV2.sol";
-import {ChainAgnosticBundlerV2} from "../../../../src/chain-agnostic/ChainAgnosticBundlerV2.sol";
+import {Permit2Bundler} from "../../../src/Permit2Bundler.sol";
+import {WNativeBundler} from "../../../src/WNativeBundler.sol";
+import {StEthBundler} from "../../../src/StEthBundler.sol";
+import {EthereumBundlerV2} from "../../../src/ethereum/EthereumBundlerV2.sol";
+import {ChainAgnosticBundlerV2} from "../../../src/chain-agnostic/ChainAgnosticBundlerV2.sol";
 
-import "../../../../config/Configured.sol";
+import "../../../config/Configured.sol";
 import "../../helpers/CommonTest.sol";
 
 abstract contract ForkTest is CommonTest, Configured {

--- a/test/fork/migration/AaveV2MigrationBundlerForkTest.sol
+++ b/test/fork/migration/AaveV2MigrationBundlerForkTest.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IStEth} from "../../../../src/interfaces/IStEth.sol";
-import {IAaveV2} from "../../../../src/migration/interfaces/IAaveV2.sol";
-import {IERC4626} from "../../../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+import {IStEth} from "../../../src/interfaces/IStEth.sol";
+import {IAaveV2} from "../../../src/migration/interfaces/IAaveV2.sol";
+import {IERC4626} from "../../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 
-import "../../../../src/migration/AaveV2MigrationBundlerV2.sol";
+import "../../../src/migration/AaveV2MigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/AaveV3MigrationBundlerForkTest.sol
+++ b/test/fork/migration/AaveV3MigrationBundlerForkTest.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.0;
 
 import {IAToken} from "./interfaces/IAToken.sol";
-import {IAaveV3} from "../../../../src/migration/interfaces/IAaveV3.sol";
+import {IAaveV3} from "../../../src/migration/interfaces/IAaveV3.sol";
 
 import {SigUtils, Permit} from "../../helpers/SigUtils.sol";
-import "../../../../src/migration/AaveV3MigrationBundlerV2.sol";
+import "../../../src/migration/AaveV3MigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/AaveV3OptimizerMigrationBundlerForkTest.sol
+++ b/test/fork/migration/AaveV3OptimizerMigrationBundlerForkTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {Authorization as AaveV3OptimizerAuthorization} from "../../../../src/migration/interfaces/IAaveV3Optimizer.sol";
+import {Authorization as AaveV3OptimizerAuthorization} from "../../../src/migration/interfaces/IAaveV3Optimizer.sol";
 
-import "../../../../src/migration/AaveV3OptimizerMigrationBundlerV2.sol";
+import "../../../src/migration/AaveV3OptimizerMigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/CompoundV2EthBorrowableMigrationBundlerForkTest.sol
+++ b/test/fork/migration/CompoundV2EthBorrowableMigrationBundlerForkTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IComptroller} from "../../../../src/migration/interfaces/IComptroller.sol";
+import {IComptroller} from "../../../src/migration/interfaces/IComptroller.sol";
 
-import "../../../../src/migration/CompoundV2MigrationBundlerV2.sol";
+import "../../../src/migration/CompoundV2MigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/CompoundV2EthCollateralMigrationBundlerForkTest.sol
+++ b/test/fork/migration/CompoundV2EthCollateralMigrationBundlerForkTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IComptroller} from "../../../../src/migration/interfaces/IComptroller.sol";
+import {IComptroller} from "../../../src/migration/interfaces/IComptroller.sol";
 
-import "../../../../src/migration/CompoundV2MigrationBundlerV2.sol";
+import "../../../src/migration/CompoundV2MigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/CompoundV2NoEthMigrationBundlerForkTest.sol
+++ b/test/fork/migration/CompoundV2NoEthMigrationBundlerForkTest.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {IComptroller} from "../../../../src/migration/interfaces/IComptroller.sol";
+import {IComptroller} from "../../../src/migration/interfaces/IComptroller.sol";
 
-import "../../../../src/migration/CompoundV2MigrationBundlerV2.sol";
+import "../../../src/migration/CompoundV2MigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/CompoundV3MigrationBundlerForkTest.sol
+++ b/test/fork/migration/CompoundV3MigrationBundlerForkTest.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {CompoundV3Authorization} from "../../helpers/SigUtils.sol";
 
-import "../../../../src/migration/CompoundV3MigrationBundlerV2.sol";
+import "../../../src/migration/CompoundV3MigrationBundlerV2.sol";
 
 import "./helpers/MigrationForkTest.sol";
 

--- a/test/fork/migration/helpers/MigrationForkTest.sol
+++ b/test/fork/migration/helpers/MigrationForkTest.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {SafeTransferLib, ERC20} from "../../../../../lib/solmate/src/utils/SafeTransferLib.sol";
-import {ErrorsLib} from "../../../../../src/libraries/ErrorsLib.sol";
-import {MarketParamsLib} from "../../../../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
-import {MorphoLib} from "../../../../../lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
-import {Market} from "../../../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
-import {MorphoBalancesLib} from "../../../../../lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
+import {SafeTransferLib, ERC20} from "../../../../lib/solmate/src/utils/SafeTransferLib.sol";
+import {ErrorsLib} from "../../../../src/libraries/ErrorsLib.sol";
+import {MarketParamsLib} from "../../../../lib/morpho-blue/src/libraries/MarketParamsLib.sol";
+import {MorphoLib} from "../../../../lib/morpho-blue/src/libraries/periphery/MorphoLib.sol";
+import {Market} from "../../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {MorphoBalancesLib} from "../../../../lib/morpho-blue/src/libraries/periphery/MorphoBalancesLib.sol";
 
 import "../../helpers/ForkTest.sol";
-import {BaseBundler} from "../../../../../src/BaseBundler.sol";
-import {PermitBundler} from "../../../../../src/PermitBundler.sol";
-import {Permit2Bundler} from "../../../../../src/Permit2Bundler.sol";
-import {ERC4626Bundler} from "../../../../../src/ERC4626Bundler.sol";
-import {MorphoBundler} from "../../../../../src/MorphoBundler.sol";
-import {ERC4626Mock} from "../../../../../src/mocks/ERC4626Mock.sol";
+import {BaseBundler} from "../../../../src/BaseBundler.sol";
+import {PermitBundler} from "../../../../src/PermitBundler.sol";
+import {Permit2Bundler} from "../../../../src/Permit2Bundler.sol";
+import {ERC4626Bundler} from "../../../../src/ERC4626Bundler.sol";
+import {MorphoBundler} from "../../../../src/MorphoBundler.sol";
+import {ERC4626Mock} from "../../../../src/mocks/ERC4626Mock.sol";
 
 contract MigrationForkTest is ForkTest {
     using SafeTransferLib for ERC20;

--- a/test/helpers/LocalTest.sol
+++ b/test/helpers/LocalTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {ERC20Mock} from "../../../src/mocks/ERC20Mock.sol";
+import {ERC20Mock} from "../../src/mocks/ERC20Mock.sol";
 
 import "./CommonTest.sol";
 

--- a/test/helpers/MetaMorphoLocalTest.sol
+++ b/test/helpers/MetaMorphoLocalTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {ERC20Mock} from "../../../src/mocks/ERC20Mock.sol";
+import {ERC20Mock} from "../../src/mocks/ERC20Mock.sol";
 
 import "./LocalTest.sol";
 

--- a/test/helpers/SigUtils.sol
+++ b/test/helpers/SigUtils.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {ICompoundV3} from "../../../src/migration/interfaces/ICompoundV3.sol";
-import {Authorization} from "../../../lib/morpho-blue/src/interfaces/IMorpho.sol";
-import {IAllowanceTransfer} from "../../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
+import {ICompoundV3} from "../../src/migration/interfaces/ICompoundV3.sol";
+import {Authorization} from "../../lib/morpho-blue/src/interfaces/IMorpho.sol";
+import {IAllowanceTransfer} from "../../lib/permit2/src/interfaces/IAllowanceTransfer.sol";
 import {
     Authorization as AaveV3OptimizerAuthorization,
     AUTHORIZATION_TYPEHASH as AAVE_V3_OPTIMIZER_AUTHORIZATION_TYPEHASH
-} from "../../../src/migration/interfaces/IAaveV3Optimizer.sol";
+} from "../../src/migration/interfaces/IAaveV3Optimizer.sol";
 import {
     Authorization as CompoundV3Authorization,
     DOMAIN_TYPEHASH as COMPOUND_V3_DOMAIN_TYPEHASH,
     AUTHORIZATION_TYPEHASH as COMPOUND_V3_AUTHORIZATION_TYPEHASH
-} from "../../../src/migration/interfaces/ICompoundV3.sol";
+} from "../../src/migration/interfaces/ICompoundV3.sol";
 
-import {PermitHash} from "../../../lib/permit2/src/libraries/PermitHash.sol";
-import {ECDSA} from "../../../lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
-import {AUTHORIZATION_TYPEHASH} from "../../../lib/morpho-blue/src/libraries/ConstantsLib.sol";
+import {PermitHash} from "../../lib/permit2/src/libraries/PermitHash.sol";
+import {ECDSA} from "../../lib/openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+import {AUTHORIZATION_TYPEHASH} from "../../lib/morpho-blue/src/libraries/ConstantsLib.sol";
 
 bytes32 constant PERMIT_TYPEHASH =
     keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");


### PR DESCRIPTION
some paths were not updated (I do not know why compilation still worked)

in addition, the change to husky's pre-commit applied `forge fmt` to files and left them in the working directory. I replaced it with `lint:fix`.